### PR TITLE
Added var keyword to allow Mocha not to complain about global scope

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -282,7 +282,7 @@ function Logger(options, _childOptions, _childSimple) {
     s = objCopy(s);
 
     // Implicit 'type' from other args.
-    type = s.type;
+    var type = s.type;
     if (!s.type) {
       if (s.stream) {
         s.type = "stream";


### PR DESCRIPTION
I've added a var statement to allow me to use bunyan in my modules and BDD them using Mocha. Without it Mocha fails the tests and complains about 'type' being leaked into the global scope.
