### PR TITLE
stdSerializers are not failsafe enough

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -907,15 +907,18 @@ Logger.stdSerializers = {};
 
 // Serialize an HTTP request.
 Logger.stdSerializers.req = function req(req) {
-  if (typeof(req) !== 'object' || typeof(req.connection) !== 'object')
+  if (typeof(req) !== 'object' || req === null)
     return req;
-  return {
+  var result = {
     method: req.method,
     url: req.url,
     headers: req.headers,
-    remoteAddress: req.connection.remoteAddress,
-    remotePort: req.connection.remotePort
   };
+  if (!(typeof(req.connection) !== 'object' || req.connection === null)) {
+    result.remoteAddress = req.connection.remoteAddress;
+    result.remotePort = req.connection.remotePort;
+  };
+  return result;
   // Trailers: Skipping for speed. If you need trailers in your app, then
   // make a custom serializers.
   //if (Object.keys(trailers).length > 0) {
@@ -925,7 +928,7 @@ Logger.stdSerializers.req = function req(req) {
 
 // Serialize an HTTP response.
 Logger.stdSerializers.res = function res(res) {
-  if (typeof(res) !== 'object')
+  if (typeof(res) !== 'object' || res === null)
     return res;
   return {
     statusCode: res.statusCode,
@@ -936,8 +939,8 @@ Logger.stdSerializers.res = function res(res) {
 // Serialize an Error object
 // (Core error properties are enumerable in node 0.4, not in 0.6).
 var errSerializer = Logger.stdSerializers.err = function err(err) {
-  if (typeof(err) !== 'object')
-    return obj;
+  if (typeof(err) !== 'object' || err === null)
+    return err;
   var obj = {
     message: err.message,
     name: err.name,


### PR DESCRIPTION
> Note: Your own serializers should never throw, otherwise you'll get an ugly message on stderr from Bunyan (along with the traceback) and the field in your log record will be replaced with a short error message.

But what about built-in serializers? :)

```
> logger.error({err:1})
bunyan: ERROR: This should never happen. This is a bug in <https://github.com/trentm/node-bunyan> or in this application. Exception from "err" Logger serializer: TypeError: Object.keys called on non-object
    at Function.keys (native)
    at Object.err (/home/alex/node_modules/bunyan/lib/bunyan.js:935:10)
    at /home/alex/node_modules/bunyan/lib/bunyan.js:572:46
    at Array.forEach (native)
    at Logger._applySerializers (/home/alex/node_modules/bunyan/lib/bunyan.js:568:33)
    at Logger._emit (/home/alex/node_modules/bunyan/lib/bunyan.js:612:12)
    at Logger.error (/home/alex/node_modules/bunyan/lib/bunyan.js:852:8)
    at repl:1:9
```
