### PR TITLE
Re-emit fs.createWriteStream errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Supported stream types are:
           "level": "warn"
         }
 
+- Bunyan re-emits error events if the file cannot be opened successfully.
 
 
 # License

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -25,6 +25,7 @@ var os = require('os');
 var fs = require('fs');
 var util = require('util');
 var assert = require('assert');
+var EventEmitter = require('events').EventEmitter;
 
 
 
@@ -168,6 +169,8 @@ function resolveLevel(nameOrNum) {
 
 
 //---- Logger class
+
+Logger.prototype = new EventEmitter;
 
 /**
  * Create a Logger instance.
@@ -316,7 +319,9 @@ function Logger(options, _childOptions, _childSimple) {
     case 'file':
       if (!s.stream) {
         s.stream = fs.createWriteStream(s.path,
-          {flags: 'a', encoding: 'utf8'});
+          {flags: 'a', encoding: 'utf8'}).on('error', function(err) {
+            self.emit('error', err);
+          });
         if (!s.closeOnExit) {
           s.closeOnExit = true;
         }


### PR DESCRIPTION
Please review.  The change allows an application using bunyan to handle FS errors gracefully rather than for example automatically exiting the process on an EACCES error.
