### PR TITLE
circular reference object resolve

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -44,19 +44,19 @@ censor = function(censor) {
 			if (typeof value === 'object' && index > -1) {
 				// Note: null can also be circular!
 				if (value === null ){
-					return 'null'
+					return 'null';
 				}
 				return '[Circular] ' + keyList[index];
 			}
 			keyList.push(key);
 			valueOrderedSet.push(value);
-			return value;  
+			return value;
 		}
 	})(censor);
 };
 
 JSON_stringify = function(obj) {
-	return JSON_stringify(obj, censor(obj));
+	return JSON.stringify(obj, censor(obj));
 };
 
 function objCopy(obj) {


### PR DESCRIPTION
Because we use simple JSON.stringify of object (without the giving user to pass stringified object as parameter), we should handle object properly, those with circular references for eg.
