### PR TITLE
remove DEBUG console.logs from rotation code

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -992,7 +992,7 @@ RotatingFileStream.prototype._setupNextRot = function () {
 }
 
 RotatingFileStream.prototype._nextRotTime = function _nextRotTime(first) {
-  var DEBUG = true;
+  var DEBUG = false;
   if (DEBUG) console.log('-- _nextRotTime: %s%s', this.periodNum, this.periodScope);
   var d = new Date();
 
@@ -1071,7 +1071,7 @@ RotatingFileStream.prototype._nextRotTime = function _nextRotTime(first) {
 RotatingFileStream.prototype.rotate = function rotate() {
   // XXX What about shutdown?
   var self = this;
-  var DEBUG = true;
+  var DEBUG = false;
 
   if (DEBUG) console.log('-- [%s] rotating %s', new Date(), self.path);
   if (self.rotating) {


### PR DESCRIPTION
Was so excited to use the log rotation code, but the console.log()'s threw off our command line tools for sphinx index generation.
