### PR TITLE
Ensure logging a non-object/non-string doesn't throw

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -743,20 +743,19 @@ function mkLogEmitter(minLevel) {
                 } else {
                     msgArgs = Array.prototype.slice.call(args, 1);
                 }
+            } else if (typeof (args[0]) !== 'object' && args[0] != null) {
+                // `log.<level>(msg, ...)`
+                fields = null;
+                msgArgs = Array.prototype.slice.call(args);
             } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
                 // Almost certainly an error, show `inspect(buf)`. See bunyan
                 // issue #35.
                 fields = null;
                 msgArgs = Array.prototype.slice.call(args);
                 msgArgs[0] = util.inspect(msgArgs[0]);
-            } else if (typeof (args[0]) === 'object' && args[0]) {
-                // `log.<level>(fields, msg, ...)`
+            } else {  // `log.<level>(fields, msg, ...)`
                 fields = args[0];
                 msgArgs = Array.prototype.slice.call(args, 1);
-            } else {
-                // `log.<level>(msg, ...)`
-                fields = null;
-                msgArgs = Array.prototype.slice.call(args);
             }
 
             // Build up the record object.

--- a/test/non-obj.test.js
+++ b/test/non-obj.test.js
@@ -46,10 +46,10 @@ test('log.info(undefined)', function (t) {
      'warn',
      'error',
      'fatal'].forEach(function (lvl) {
-        log[lvl].call(log, undef);
+        log[lvl].call(log, undef, 'some message');
         var rec = catcher.records[catcher.records.length - 1];
-        t.equal(rec.msg, 'undefined',
-            format('log.%s msg is "undefined"', lvl));
+        t.equal(rec.msg, 'some message',
+            format('log.%s msg is "some message"', lvl));
         t.ok(rec['0'] === undefined,
             'no "0" array index key in record: ' + inspect(rec['0']));
         t.ok(rec['parent'] === undefined,
@@ -68,10 +68,10 @@ test('log.info(null)', function (t) {
      'warn',
      'error',
      'fatal'].forEach(function (lvl) {
-        log[lvl].call(log, nullObj);
+        log[lvl].call(log, nullObj, 'some message');
         var rec = catcher.records[catcher.records.length - 1];
-        t.equal(rec.msg, 'null',
-            format('log.%s msg is "null"', lvl));
+        t.equal(rec.msg, 'some message',
+            format('log.%s msg is "some message"', lvl));
         t.ok(rec['0'] === undefined,
             'no "0" array index key in record: ' + inspect(rec['0']));
         t.ok(rec['parent'] === undefined,


### PR DESCRIPTION
This fixes the following exception:

```
> log.info(23)
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at objCopy (/bunyan/lib/bunyan.js:54:16)
    at mkRecord (/bunyan/lib/bunyan.js:764:39)
    at Logger.info (/bunyan/lib/bunyan.js:795:19)
```

Not sure exactly what you want to do for `undefined`/`null`/`Function` types - I've just left them being converted without special cases - but they don't throw at least (check the attached test for details)
