### PR TITLE
have log emitter return emitted log record

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -800,6 +800,7 @@ function mkLogEmitter(minLevel) {
                     (rec && log._emit(rec, true)) ||
                     log._emit(mkRecord(msgArgs), true) ];
         });
+        return rec;
     }
 }
 


### PR DESCRIPTION
Returning the log record instead of null allows the consumer of the logger to use the log in additional ways.

This change passes the test suite with node 0.6.21, 0.8.25 and 0.10.11. If there are other specific versions I need to test with, please let me know.
