### PR TITLE
Rotating-file stream prevent process from exiting.

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -990,6 +990,9 @@ RotatingFileStream.prototype._setupNextRot = function () {
     this.timeout = setTimeout(
         function () { self.rotate(); },
         this.rotAt - Date.now());
+    if (typeof this.timeout.unref === 'function') {
+      this.timeout.unref();
+    }
 }
 
 RotatingFileStream.prototype._nextRotTime = function _nextRotTime(first) {


### PR DESCRIPTION
Related: #73 

If I `bunyan.createLogger` with a `type: "rotating-file"`, my process will not exits.

I've tried the solution in #73 but it does not work and my CLI program stays running even though it doesn't do anything.

Removing the rotating-file logger causes my very trivial program to exit cleanly.

Is there a way to force the logger to close all streams?

This is also very problematic in tests as having a component using the rotating-file logger means the test will not cleanup properly or the test runner may not exit and hangs the CI :/
