### PR TITLE
Make condition queries faster

### DIFF
--- a/bin/bunyan
+++ b/bin/bunyan
@@ -69,10 +69,12 @@ var levelFromName = {
 var nameFromLevel = {};
 var upperNameFromLevel = {};
 var upperPaddedNameFromLevel = {};
+var condDefines = {};
 Object.keys(levelFromName).forEach(function (name) {
     var lvl = levelFromName[name];
     nameFromLevel[lvl] = name;
     upperNameFromLevel[lvl] = name.toUpperCase();
+    condDefines[name.toUpperCase()] = lvl;
     upperPaddedNameFromLevel[lvl] = (
         name.length === 4 ? ' ' : '') + name.toUpperCase();
 });
@@ -278,13 +280,21 @@ function filterRecord(rec, opts)
 
     if (opts.conditions) {
         for (var i = 0; i < opts.conditions.length; i++) {
-            var pass = opts.conditions[i].runInNewContext(rec);
+            var pass = testCondition.call(rec, opts.conditions[i]);
             if (!pass)
                 return false;
         }
     }
 
     return true;
+}
+
+// Note that this function is called with the record as context.
+function testCondition(code) {
+    this.__proto__ = condDefines;
+    with (this) {
+        return eval(code);
+    }
 }
 
 function emitNextRecord(opts, stylize)
@@ -400,13 +410,6 @@ function parseArgv(argv) {
     }
     args = newArgs;
 
-    var condDefines = [];
-    Object.keys(upperNameFromLevel).forEach(function (lvl) {
-        condDefines.push(
-            format('Object.prototype.%s = %s;', upperNameFromLevel[lvl], lvl));
-    });
-    condDefines = condDefines.join('\n') + '\n';
-
     var endOfOptions = false;
     while (args.length > 0) {
         var arg = args.shift();
@@ -496,22 +499,10 @@ function parseArgv(argv) {
             case '--condition':
                 var condition = args.shift();
                 parsed.conditions = parsed.conditions || [];
-                var scriptName = 'bunyan-condition-'+parsed.conditions.length;
-                var code = condDefines + condition;
-                try {
-                    var script = vm.createScript(code, scriptName);
-                } catch (compileErr) {
-                    throw new Error(format('illegal CONDITION code: %s\n'
-                        + '  CONDITION script:\n'
-                        + '%s\n'
-                        + '  Error:\n'
-                        + '%s',
-                        compileErr, indent(code), indent(compileErr.stack)));
-                }
 
                 // Ensure this is a reasonably safe CONDITION.
                 try {
-                    script.runInNewContext(minValidRecord);
+                    testCondition.call(minValidRecord, condition);
                 } catch (condErr) {
                     throw new Error(format(
                         /* JSSTYLED */
@@ -522,13 +513,13 @@ function parseArgv(argv) {
                         + '%s\n'
                         + '  Filter error:\n'
                         + '%s',
-                        indent(code),
+                        indent(condition),
                         indent(JSON.stringify(minValidRecord, null, 2)),
                         indent(condErr.stack)
                         ));
                 }
 
-                parsed.conditions.push(script);
+                parsed.conditions.push(condition);
                 break;
             default: // arguments
                 if (!endOfOptions && arg.length > 0 && arg[0] === '-') {


### PR DESCRIPTION
Initial benchmark shows ~700x improvement.

It doesn't use sandbox so its not 100% compatible with previous version but I think its very hard to accidentally leak anything. On the other hand it now allows combining conditions for some complex queries.

I started with a version that uses `new Function()` instead of `eval`. https://github.com/tonistiigi/node-bunyan/compare/master...condition-function In my opinion its cleaner but in this version condition needs to be a Javascript expression. So instead on `if()` you would have to use `?:` etc. (dtrace users should be used to this). Anyway, it also turned out to be slower than `eval`. The slow part is the assignment of `__proto__` for the log level definitions, without it its faster than `eval`.
##### Benchmark results:

Tested on a real log file with 1k/30k rows. Conditions matched for ~5% of the rows.

Original 1k rows: **12.557s**    [flamegraph](https://us-east.manta.joyent.com/tonistiigi/public/bunyan-bench/00-original.svg)
Eval 30k rows: **0.449s** [flamegraph](https://us-east.manta.joyent.com/tonistiigi/public/bunyan-bench/02-eval.svg)
Function 30k rows: **0.551s** [flamegraph](https://us-east.manta.joyent.com/tonistiigi/public/bunyan-bench/01-function.svg)
Eval no dunder proto 30k rows: **0.424s** [flamegraph](https://us-east.manta.joyent.com/tonistiigi/public/bunyan-bench/02-eval-noproto.svg)
Function no dunder proto 30k rows: **0.390s** [flamegraph](https://us-east.manta.joyent.com/tonistiigi/public/bunyan-bench/01-function-noproto.svg)
