### PR TITLE
added integration with source-map-support for integration with sourcemaps

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -113,8 +113,16 @@ function getCaller3Info() {
     var savePrepare = Error.prepareStackTrace;
     Error.stackTraceLimit = 3;
     Error.captureStackTrace(this, getCaller3Info);
+
+    var sourcemapSupport = true;
+    try { require.resolve("source-map-support"); }
+    catch ( e ) { sourcemapSupport = false; }
+    
     Error.prepareStackTrace = function (_, stack) {
         var caller = stack[2];
+        if (sourcemapSupport) {
+            caller = require("source-map-support").wrapCallSite(caller);
+        }
         obj.file = caller.getFileName();
         obj.line = caller.getLineNumber();
         var func = caller.getFunctionName();


### PR DESCRIPTION
In order to support sourcemaps (eg when using coffeescript) I think node-bunyan should integrate with `node-source-map-support` when it is available.

This depends upon the pull-request https://github.com/evanw/node-source-map-support/pull/28 at `node-source-map-support`.

Thanks!