### PR TITLE
add `error` to list of log levels in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This will dove-tail with [Bunyan serializer support](#serializers), discussed
 later.
 
 The same goes for all of Bunyan's log levels: `log.trace`, `log.debug`,
-`log.info`, `log.warn`, and `log.fatal`. See the [levels section](#levels)
+`log.info`, `log.warn`, `log.error`, and `log.fatal`. See the [levels section](#levels)
 below for details and suggestions.
 
 


### PR DESCRIPTION
The `error` level was left out of a sentence in the readme.
