### PR TITLE
Fix crash from `bunyan` CLI with an `Object.keys called on non-object` message

### DIFF
--- a/bin/bunyan
+++ b/bin/bunyan
@@ -754,14 +754,21 @@ function emitRecord(rec, line, opts, stylize) {
             var req = rec.req;
             delete rec.req;
             var headers = req.headers;
+            if (!headers) {
+                headers = '';
+            }
+            else if (typeof headers === 'string') {
+                headers = '\n' + headers;
+            }
+            else if (typeof headers === 'object') {
+                headers = '\n' + Object.keys(headers).map(function (h) {
+                    return h + ': ' + headers[h];
+                }).join('\n');
+            }
             var s = format('%s %s HTTP/%s%s', req.method,
                 req.url,
                 req.httpVersion || '1.1',
-                (headers ?
-                    '\n' + Object.keys(headers).map(function (h) {
-                        return h + ': ' + headers[h];
-                    }).join('\n') :
-                    '')
+                headers
             );
             delete req.url;
             delete req.method;


### PR DESCRIPTION
Sending a log message with a non-object value for the `req` property to the `bunyan` CLI causes it to crash with an `Object.keys called on non-object` message. This change fixes that.
