### PR TITLE
Improve short output

### DIFF
--- a/bin/bunyan
+++ b/bin/bunyan
@@ -705,6 +705,7 @@ function emitRecord(rec, line, opts, stylize) {
         delete rec.pid;
 
         var level = (upperPaddedNameFromLevel[rec.level] || 'LVL' + rec.level);
+        var rawLevel = rec.level;
         if (opts.color) {
             var colorFromLevel = {
                 10: 'grey',     // TRACE
@@ -916,6 +917,15 @@ function emitRecord(rec, line, opts, stylize) {
                 onelineMsg,
                 extras,
                 details));
+        else if (rawLevel > INFO) {
+            emit(format('%s %s %s:%s%s\n%s',
+                time,
+                level,
+                nameStr,
+                onelineMsg,
+                extras,
+                details));
+        }
         else
             emit(format('%s %s %s:%s%s\n',
                 time,

--- a/bin/bunyan
+++ b/bin/bunyan
@@ -917,13 +917,12 @@ function emitRecord(rec, line, opts, stylize) {
                 extras,
                 details));
         else
-            emit(format('%s %s %s:%s%s\n%s',
+            emit(format('%s %s %s:%s%s\n',
                 time,
                 level,
                 nameStr,
                 onelineMsg,
-                extras,
-                details));
+                extras));
         break;
 
     case OM_INSPECT:


### PR DESCRIPTION
Removed "details" from CLI output when using "short" format. However, do include the details info when level is error, so that error info is still displayed.