### PR TITLE
Add env var to turn off

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -733,7 +733,7 @@ Logger.prototype._emit = function (rec, noemit) {
         str = JSON.stringify(rec, safeCycles()) + '\n';
     }
 
-    if (noemit || (process.env.BUNYAN_OFF===1))
+    if (noemit || (process.env.BUNYAN_OFF==='true'))
         return str;
 
     var level = rec.level;


### PR DESCRIPTION
Added the support of a environment variable called BUNYAN_OFF that allows you to turn off logging, in my case, during unit tests.
