### PR TITLE
converted 'helpers' to members - post-instantiation configuration

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -336,108 +336,21 @@ function Logger(options, _childOptions, _childSimple) {
         dtp.enable();
     }
 
-    // Helpers
-    function addStream(s) {
-        s = objCopy(s);
-
-        // Implicit 'type' from other args.
-        var type = s.type;
-        if (!s.type) {
-            if (s.stream) {
-                s.type = 'stream';
-            } else if (s.path) {
-                s.type = 'file'
-            }
-        }
-        s.raw = (s.type === 'raw');  // PERF: Allow for faster check in `_emit`.
-
-        if (s.level) {
-            s.level = resolveLevel(s.level);
-        } else if (options.level) {
-            s.level = resolveLevel(options.level);
-        } else {
-            s.level = INFO;
-        }
-        if (s.level < self._level) {
-            self._level = s.level;
-        }
-
-        switch (s.type) {
-        case 'stream':
-            if (!s.closeOnExit) {
-                s.closeOnExit = false;
-            }
-            break;
-        case 'file':
-            if (!s.stream) {
-                s.stream = fs.createWriteStream(s.path,
-                    {flags: 'a', encoding: 'utf8'});
-                s.stream.on('error', function (err) {
-                    self.emit('error', err, s);
-                });
-                if (!s.closeOnExit) {
-                    s.closeOnExit = true;
-                }
-            } else {
-                if (!s.closeOnExit) {
-                    s.closeOnExit = false;
-                }
-            }
-            break;
-        case 'rotating-file':
-            assert.ok(!s.stream,
-                '"rotating-file" stream should not give a "stream"');
-            assert.ok(s.path);
-            assert.ok(mv, '"rotating-file" stream type is not supported: '
-                + 'missing "mv" module');
-            s.stream = new RotatingFileStream(s);
-            if (!s.closeOnExit) {
-                s.closeOnExit = true;
-            }
-            break;
-        case 'raw':
-            if (!s.closeOnExit) {
-                s.closeOnExit = false;
-            }
-            break;
-        default:
-            throw new TypeError('unknown stream type "' + s.type + '"');
-        }
-
-        self.streams.push(s);
-    }
-
-    function addSerializers(serializers) {
-        if (!self.serializers) {
-            self.serializers = {};
-        }
-        Object.keys(serializers).forEach(function (field) {
-            var serializer = serializers[field];
-            if (typeof (serializer) !== 'function') {
-                throw new TypeError(format(
-                    'invalid serializer for "%s" field: must be a function',
-                    field));
-            } else {
-                self.serializers[field] = serializer;
-            }
-        });
-    }
-
     // Handle *config* options (i.e. options that are not just plain data
     // for log records).
     if (options.stream) {
-        addStream({
+        this.addStream({
             type: 'stream',
             stream: options.stream,
             closeOnExit: false,
             level: (options.level ? resolveLevel(options.level) : INFO)
         });
     } else if (options.streams) {
-        options.streams.forEach(addStream);
+        for (var i in options.streams) this.addStream (options.streams[i]);
     } else if (parent && options.level) {
         this.level(options.level);
     } else if (!parent) {
-        addStream({
+        this.addStream({
             type: 'stream',
             stream: process.stdout,
             closeOnExit: false,
@@ -445,7 +358,7 @@ function Logger(options, _childOptions, _childSimple) {
         });
     }
     if (options.serializers) {
-        addSerializers(options.serializers);
+        this.addSerializers(options.serializers);
     }
     if (options.src) {
         this.src = true;
@@ -479,6 +392,107 @@ function Logger(options, _childOptions, _childSimple) {
 
 util.inherits(Logger, EventEmitter);
 
+
+/**
+ * Add a stream to this Logger by providing a `stream` definition Object as 
+ *        normally found in `options.streams`.
+ *
+ * @param stream {Object} A single Array Element like you would normally find in 
+ *        `options.streams`.
+ */
+Logger.prototype.addStream = function (s) {
+    s = objCopy(s);
+
+    // Implicit 'type' from other args.
+    var type = s.type;
+    if (!s.type) {
+        if (s.stream) {
+            s.type = 'stream';
+        } else if (s.path) {
+            s.type = 'file'
+        }
+    }
+    s.raw = (s.type === 'raw');  // PERF: Allow for faster check in `_emit`.
+
+    if (s.level) {
+        s.level = resolveLevel(s.level);
+    } else if (options.level) {
+        s.level = resolveLevel(options.level);
+    } else {
+        s.level = INFO;
+    }
+    if (s.level < this._level) {
+        this._level = s.level;
+    }
+
+    switch (s.type) {
+    case 'stream':
+        if (!s.closeOnExit) {
+            s.closeOnExit = false;
+        }
+        break;
+    case 'file':
+        if (!s.stream) {
+            s.stream = fs.createWriteStream(s.path,
+                {flags: 'a', encoding: 'utf8'});
+            s.stream.on('error', function (err) {
+                this.emit('error', err, s);
+            });
+            if (!s.closeOnExit) {
+                s.closeOnExit = true;
+            }
+        } else {
+            if (!s.closeOnExit) {
+                s.closeOnExit = false;
+            }
+        }
+        break;
+    case 'rotating-file':
+        assert.ok(!s.stream,
+            '"rotating-file" stream should not give a "stream"');
+        assert.ok(s.path);
+        assert.ok(mv, '"rotating-file" stream type is not supported: '
+            + 'missing "mv" module');
+        s.stream = new RotatingFileStream(s);
+        if (!s.closeOnExit) {
+            s.closeOnExit = true;
+        }
+        break;
+    case 'raw':
+        if (!s.closeOnExit) {
+            s.closeOnExit = false;
+        }
+        break;
+    default:
+        throw new TypeError('unknown stream type "' + s.type + '"');
+    }
+
+    this.streams.push(s);
+};
+
+/**
+ * Add serializers to this Logger by providing a definition Object as normally found
+ *        at `options.serializers`.
+ *
+ * @param serializers {Object} An object mapping log record field names to 
+ *        serializing functions. These serializers will be added to the existing 
+ *        pool, with new serializers clobbering old ones.
+ */
+Logger.prototype.addSerializers = function (serializers) {
+    if (!this.serializers) {
+        this.serializers = {};
+    }
+    for (var field in serializers) {
+        var serializer = serializers[field];
+        if (typeof (serializer) != 'function') {
+            throw new TypeError(format(
+                'invalid serializer for "%s" field: must be a function',
+                field));
+        } else {
+            this.serializers[field] = serializer;
+        }
+    }
+};
 
 /**
  * Create a child logger, typically to add a few log record fields.


### PR DESCRIPTION
I needed to add a stream to an existing `Logger` instance. This change converts the two closures after `// Helpers` into a pair of member functions.
