### PR TITLE
Request Serializer: Use req.originalUrl over req.url

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -942,7 +942,7 @@ Logger.stdSerializers.req = function req(req) {
         return req;
     return {
         method: req.method,
-        url: req.url,
+        url: req.originalUrl || req.url,
         headers: req.headers,
         remoteAddress: req.connection.remoteAddress,
         remotePort: req.connection.remotePort

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -56,6 +56,15 @@ test('req serializer', function (t) {
         t.equal(records[i].req, bogusReqs[i]);
     }
 
+    // Test originalUrl
+    var originalUrlReq = {
+      url: "/",
+      originalUrl: "/foo/bar",
+      connection: {}, // fake connection object
+    };
+    log.info({req: originalUrlReq}, 'hi');
+    t.equal(records[records.length-1].req.url, originalUrlReq.originalUrl);
+
     // Get http request and response objects to play with and test.
     var theReq, theRes;
     var server = http.createServer(function (req, res) {


### PR DESCRIPTION
Sometimes `req.url` is modified for the purpose of routing [1]. In these cases the convention is to set `req.originalUrl` to the url originally requested [2]. When logging, it's more useful to have the full original url than it is to have the current state of `req.url` as it will depend on where in the routing chain you are.

This changes `bunyan.stdSerializers.req` to prefer using `req.originalUrl` over `req.url` when available.

This change is backwards compatible and should only change the minor (maybe patch) version.

[1] https://github.com/strongloop/express/blob/728917164cc00dd02382560f52c6f78936adb4c3/lib/router/index.js#L251
[2] https://github.com/strongloop/express/blob/728917164cc00dd02382560f52c6f78936adb4c3/lib/router/index.js#L163
