### PR TITLE
Added stackTraceLimit to the options of Logger

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -418,6 +418,7 @@ function Logger(options, _childOptions, _childSimple) {
     delete fields.streams;
     delete fields.serializers;
     delete fields.src;
+    delete fields.stackTraceLimit;
     if (this.serializers) {
         this._applySerializers(fields);
     }


### PR DESCRIPTION
We are using Kibana, Logstash and Elastic search to pull the logs onto a server to analyize and needed a way to verify a certain schema in the info object passed to mkLogEmitter. While doing this, the stacktrace was actually 2 levels deeper than what getCaller3Info was looking for. Added stackTraceLimit to the options in Logger and passing that number to getCaller3Info fixed our problem.
