### PR TITLE
Solution to fix #175: Mute log record emission through Environment Variables

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -770,6 +770,53 @@ Logger.prototype._applySerializers = function (fields, excludeFields) {
     });
 }
 
+/**
+ * Returns the given object's "o" property named by "s" using the dot notation.
+ *
+ * this({ nane: { first: "value" } }, name.first) == "value"
+ *
+ * This is a verbatin copy of http://stackoverflow.com/a/6491621/433814
+ *
+ * @param o {object} is an object.
+ * @param s (string} is the string in the "dot" notation.
+ */
+Logger.prototype._objectFromDotNotation = function (o, s) {
+    s = s.replace(/\[(\w+)\]/g, '.$1');  // convert indexes to properties
+    s = s.replace(/^\./, ''); // strip leading dot
+    var a = s.split('.');
+    while (a.length) {
+        var n = a.shift();
+        if (n in o) {
+            o = o[n];
+        } else {
+            return;
+        }
+    }
+    return o;
+}
+
+/**
+ * Verifies whether the given record should be disabled based on env variable key=value
+ * process.env.BUNYAN_REC_DISABLE_object.property.notation = value.
+ * @param rec {log record}
+ */
+Logger.prototype._disableByEnv = function (rec) {
+    for (var envProp in process.env) {
+        if (envProp.indexOf("BUNYAN_REC_DISABLE_") == 0) {
+            try {
+                var requestedDisableProperty = envProp.replace("BUNYAN_REC_DISABLE_", "");
+                var requestedDisabledObject = this._objectFromDotNotation(rec, requestedDisableProperty);
+                if (requestedDisabledObject === process.env[envProp]) {
+                    return true;
+                }
+
+            } catch (ObjectNotFound) {
+              // Not showing anything
+            }
+        }
+    }
+    return false;
+}
 
 /**
  * Emit a log record.
@@ -798,6 +845,8 @@ Logger.prototype._emit = function (rec, noemit) {
     if (noemit || this.haveNonRawStreams) {
         str = JSON.stringify(rec, safeCycles()) + '\n';
     }
+
+    noemit = this._disableByEnv(rec);
 
     if (noemit)
         return str;

--- a/test/log-env-disabled.test.js
+++ b/test/log-env-disabled.test.js
@@ -5,6 +5,7 @@
 
 // Records that has this name will NOT be emitted.
 process.env.BUNYAN_REC_DISABLE_name = "to-be-disabled";
+process.env["BUNYAN_REC_DISABLE_fullName.first"] = "Marcello";
 
 var util = require('util'),
     format = util.format,
@@ -73,6 +74,24 @@ var names = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 test('log.info(null, disabled by "name")', function (t) {
     names.forEach(function (lvl) {
         log3[lvl].call(log3, null, 'some message');
+        var rec = catcher.records[catcher.records.length - 1];
+        t.notEqual(rec, 'undefined');
+    });
+    delete process.env.BUNYAN_REC_DISABLE_name;
+    t.end();
+});
+
+test('log.info(null, disabled by "object value")', function (t) {
+
+    var myObj = {
+        fullName: {
+            first: "Marcello",
+            last: "deSales"
+        }
+    };
+
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, myObj, 'some message');
         var rec = catcher.records[catcher.records.length - 1];
         t.notEqual(rec, 'undefined');
     });

--- a/test/log-env-disabled.test.js
+++ b/test/log-env-disabled.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014 Trent Mick. All rights reserved.
+ *
+ */
+
+// Records that has this name will NOT be emitted.
+process.env.BUNYAN_REC_DISABLE_name = "to-be-disabled";
+
+var util = require('util'),
+    format = util.format,
+    inspect = util.inspect;
+var p = console.log;
+
+var bunyan = require('../lib/bunyan');
+
+// node-tap API
+if (require.cache[__dirname + '/tap4nodeunit.js'])
+        delete require.cache[__dirname + '/tap4nodeunit.js'];
+var tap4nodeunit = require('./tap4nodeunit.js');
+var after = tap4nodeunit.after;
+var before = tap4nodeunit.before;
+var test = tap4nodeunit.test;
+
+
+// ---- test boolean `log.<level>()` calls
+
+var log1 = bunyan.createLogger({
+    name: 'log1',
+    streams: [
+        {
+            path: __dirname + '/log.test.log1.log',
+            level: 'info'
+        }
+    ]
+});
+
+var log2 = bunyan.createLogger({
+    name: 'log2',
+    streams: [
+        {
+            path: __dirname + '/log.test.log2a.log',
+            level: 'error'
+        },
+        {
+            path: __dirname + '/log.test.log2b.log',
+            level: 'debug'
+        }
+    ]
+})
+
+// ---- test `log.<level>(...)` calls which various input types
+
+function Catcher() {
+    this.records = [];
+}
+Catcher.prototype.write = function (record) {
+    this.records.push(record);
+}
+var catcher = new Catcher();
+var log3 = new bunyan.createLogger({
+    name: 'to-be-disabled',
+    streams: [
+        {
+            type: 'raw',
+            stream: catcher,
+            level: 'trace'
+        }
+    ]
+});
+
+var names = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
+
+test('log.info(null, disabled by "name")', function (t) {
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, null, 'some message');
+        var rec = catcher.records[catcher.records.length - 1];
+        t.notEqual(rec, 'undefined');
+    });
+    delete process.env.BUNYAN_REC_DISABLE_name;
+    t.end();
+});


### PR DESCRIPTION
This commit adds the function that initially fixes #175 by disabling the
record being emitted. Requirements are described in the issue #175.

*	modified:   lib/bunyan.js
- Adding a helper method to disable objects by properties

*	new file:   test/log-env-disabled.test.js
- Adding the disable test case by setting the environment var before loading
  the record.