### PR TITLE
Defend against throwing defined properties in json stringify

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -37,6 +37,7 @@ try {
     dtrace = null;
 }
 var EventEmitter = require('events').EventEmitter;
+var safeJsonStringify = require('safe-json-stringify');
 
 // The 'mv' module is required for rotating-file stream support.
 try {
@@ -92,7 +93,12 @@ if (!format) {
             switch (x) {
                 case '%s': return String(args[i++]);
                 case '%d': return Number(args[i++]);
-                case '%j': return JSON.stringify(args[i++], safeCycles());
+                case '%j':
+				try {
+					return JSON.stringify(args[i++], safeCycles());
+				} catch(err) {
+					return safeJsonStringify(args[i++]);
+				}
                 case '%%': return '%';
                 default:
                     return x;
@@ -796,7 +802,12 @@ Logger.prototype._emit = function (rec, noemit) {
     // Stringify the object. Attempt to warn/recover on error.
     var str;
     if (noemit || this.haveNonRawStreams) {
-        str = JSON.stringify(rec, safeCycles()) + '\n';
+		try {
+			str = JSON.stringify(rec, safeCycles()) + '\n';
+		}
+		catch(err) {
+			str = safeJsonStringify(rec) + '\n';
+		}
     }
 
     if (noemit)

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -93,12 +93,7 @@ if (!format) {
             switch (x) {
                 case '%s': return String(args[i++]);
                 case '%d': return Number(args[i++]);
-                case '%j':
-                try {
-                    return JSON.stringify(args[i++], safeCycles());
-                } catch(err) {
-                    return safeJsonStringify(args[i++]);
-                }
+                case '%j': return JSON.stringify(args[i++], safeCycles());
                 case '%%': return '%';
                 default:
                     return x;

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -37,7 +37,12 @@ try {
     dtrace = null;
 }
 var EventEmitter = require('events').EventEmitter;
-var safeJsonStringify = require('safe-json-stringify');
+
+try {
+    var safeJsonStringify = require('safe-json-stringify');
+} catch (e) {
+    safeJsonStringify = null;
+}
 
 // The 'mv' module is required for rotating-file stream support.
 try {
@@ -801,7 +806,16 @@ Logger.prototype._emit = function (rec, noemit) {
             str = JSON.stringify(rec, safeCycles()) + '\n';
         }
         catch(err) {
-            str = safeJsonStringify(rec) + '\n';
+            if (safeJsonStringify) {
+                str = safeJsonStringify(rec) + '\n';
+            }
+            else {
+                str = '(Could not JSON stringify data. See stderr for details.)';
+                _warn(format('bunyan: ERROR: Could not JSON stringify a property. '
+                    + 'Please consider installing safe-json-stringify for more '
+                    + 'information. Stack trace: %s'
+                , err.stack));
+            }
         }
     }
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -94,11 +94,11 @@ if (!format) {
                 case '%s': return String(args[i++]);
                 case '%d': return Number(args[i++]);
                 case '%j':
-				try {
-					return JSON.stringify(args[i++], safeCycles());
-				} catch(err) {
-					return safeJsonStringify(args[i++]);
-				}
+                try {
+                    return JSON.stringify(args[i++], safeCycles());
+                } catch(err) {
+                    return safeJsonStringify(args[i++]);
+                }
                 case '%%': return '%';
                 default:
                     return x;
@@ -802,12 +802,12 @@ Logger.prototype._emit = function (rec, noemit) {
     // Stringify the object. Attempt to warn/recover on error.
     var str;
     if (noemit || this.haveNonRawStreams) {
-		try {
-			str = JSON.stringify(rec, safeCycles()) + '\n';
-		}
-		catch(err) {
-			str = safeJsonStringify(rec) + '\n';
-		}
+        try {
+            str = JSON.stringify(rec, safeCycles()) + '\n';
+        }
+        catch(err) {
+            str = safeJsonStringify(rec) + '\n';
+        }
     }
 
     if (noemit)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "bin": {
     "bunyan": "./bin/bunyan"
   },
+
   "repository": {
     "type": "git",
     "url": "git://github.com/trentm/node-bunyan.git"
@@ -14,18 +15,14 @@
   "engines": [
     "node >=0.8.0"
   ],
-  "keywords": [
-    "log",
-    "logging",
-    "log4j",
-    "json",
-    "bunyan"
-  ],
+  "keywords": ["log", "logging", "log4j", "json", "bunyan"],
+
   "// comment1": "'dtrace-provider' required for dtrace features",
   "// comment2": "'mv' required for RotatingFileStream",
   "optionalDependencies": {
     "dtrace-provider": "~0.3 >0.3.0",
-    "mv": "~2"
+    "mv": "~2",
+    "safe-json-stringify": "1.0.1"
   },
   "devDependencies": {
     "nodeunit": "0.9.*",
@@ -33,10 +30,8 @@
     "verror": "1.3.3",
     "vasync": "1.4.3"
   },
+
   "scripts": {
     "test": "make test"
-  },
-  "dependencies": {
-    "safe-json-stringify": "1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,20 @@
   "bin": {
     "bunyan": "./bin/bunyan"
   },
-
   "repository": {
     "type": "git",
     "url": "git://github.com/trentm/node-bunyan.git"
   },
-  "engines": ["node >=0.8.0"],
-  "keywords": ["log", "logging", "log4j", "json", "bunyan"],
-
+  "engines": [
+    "node >=0.8.0"
+  ],
+  "keywords": [
+    "log",
+    "logging",
+    "log4j",
+    "json",
+    "bunyan"
+  ],
   "// comment1": "'dtrace-provider' required for dtrace features",
   "// comment2": "'mv' required for RotatingFileStream",
   "optionalDependencies": {
@@ -27,8 +33,10 @@
     "verror": "1.3.3",
     "vasync": "1.4.3"
   },
-
   "scripts": {
     "test": "make test"
+  },
+  "dependencies": {
+    "safe-json-stringify": "1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "type": "git",
     "url": "git://github.com/trentm/node-bunyan.git"
   },
-  "engines": [
-    "node >=0.8.0"
-  ],
+  "engines": ["node >=0.8.0"],
   "keywords": ["log", "logging", "log4j", "json", "bunyan"],
 
   "// comment1": "'dtrace-provider' required for dtrace features",


### PR DESCRIPTION
If an object has a defined property, that is enumerable, and this property throws an error, it will make JSON stringify throw an error, and potentially bring down the program.

The solution so far is to try-catch with the usual json stringifyer, that guards against circular references. If this throws an error we will attempt to guard against defined properties; and return *[Throws]* if a property throws an error when accesed.

The following examples illustrate the problem:

```js
var obj = {};
obj.__defineGetter__('foo', function() { throw new Error('ouch!'); });

JSON.stringify(obj.foo); // error thrown
```

And using `Object.defineProperty`:
```js
var obj = {};
Object.defineProperty(obj, 'foo', {
    get: function() { throw new Error('ouch!'); }
    enumerable: true // enumerable is false by default
});

JSON.stringify(obj.foo); // error thrown
```

The cases we have seen in production is third party modules that has enumerable getters that try to access properties on undefined objects.