### PR TITLE
Handle far future timeouts for logrotation

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1085,9 +1085,13 @@ util.inherits(RotatingFileStream, EventEmitter);
 RotatingFileStream.prototype._setupNextRot = function () {
     var self = this;
     this.rotAt = this._nextRotTime();
+    var delay = this.rotAt - Date.now();
+    if (delay > 2147483647) {
+        delay = 2147483647;
+    }
     this.timeout = setTimeout(
         function () { self.rotate(); },
-        this.rotAt - Date.now());
+        delay);
     if (typeof (this.timeout.unref) === 'function') {
         this.timeout.unref();
     }
@@ -1177,6 +1181,10 @@ RotatingFileStream.prototype.rotate = function rotate() {
     // XXX What about shutdown?
     var self = this;
     var _DEBUG = false;
+
+    if (self.rotAt && self.rotAt > Date.now()) {
+        return self._setupNextRot();
+    }
 
     if (_DEBUG) {
         console.log('-- [%s, pid=%s] rotating %s',


### PR DESCRIPTION
Limit the delay to 2147483647 and then check in rotate() whether we should actually rotate the files or just issue another timeout.
