### PR TITLE
Add axtra new line in long output format

### DIFF
--- a/bin/bunyan
+++ b/bin/bunyan
@@ -786,7 +786,7 @@ function emitRecord(rec, line, opts, stylize) {
         delete rec.req_id;
 
         var onelineMsg;
-        if (rec.msg.indexOf('\n') !== -1) {
+        if (!short || rec.msg.indexOf('\n') !== -1) {
             onelineMsg = '';
             details.push(indent(stylize(rec.msg, 'cyan')));
         } else {


### PR DESCRIPTION
I find, that logs in full format get quite long, especially when source location is printed. From my experimentation I find it quite useful to have a message on new line. It makes it also easier to quickly scan entries for particular message, when debugging.

Please consider adding my patch to upstream release version. I am fine to spend some time tning output format if you have some other suggestion for this problem.