### PR TITLE
Fix line numbers reported in coffescript stacktrace

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -120,14 +120,32 @@ function getCaller3Info() {
     var savePrepare = Error.prepareStackTrace;
     Error.stackTraceLimit = 3;
     Error.captureStackTrace(this, getCaller3Info);
-    Error.prepareStackTrace = function (_, stack) {
+    function prepareNativeStackTrace(_, stack) {
         var caller = stack[2];
+        if (!caller)
+            caller = stack[2];
         obj.file = caller.getFileName();
         obj.line = caller.getLineNumber();
         var func = caller.getFunctionName();
         if (func)
             obj.func = func;
-    };
+    }
+    if (savePrepare) {
+        Error.prepareStackTrace = function (_, stack) {
+            try {
+                var lines = savePrepare(_, stack).split(/\n\s*at/);
+                var parts = lines[3].match(/\s*((.*) \()?(.+):([0-9]+):([0-9]+)\)?\n?$/);
+                obj.file = parts[3];
+                obj.line = parts[4];
+                if (parts[2])
+                    obj.func = parts[2];
+            } catch (err) {
+                prepareNativeStackTrace(_, stack);
+            }
+        };
+    } else {
+        Error.prepareStackTrace = prepareNativeStackTrace;
+    }
     this.stack;
     Error.stackTraceLimit = saveLimit;
     Error.prepareStackTrace = savePrepare;


### PR DESCRIPTION
When using bunyan with coffeescript aplication line numbers reported in errors and stack trace are wrong. I spent some time investigating the issue. It turns out that both bunyan and coffeescript engine are overwriting the same method to get those lines _Error.prepareStackTrace_. I found a solution to a problem by chaining those methods, if other application already provided it. That way bunan will report stacktrace line numbers, which have been processed and adjusted by coffeescript processor.

Please consider adding my patch to upstream version.
