### PR TITLE
Don't make objCopy crash on non-objects

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -55,16 +55,18 @@ var isBrowser = function () {
 //---- Internal support stuff
 
 function objCopy(obj) {
-    if (obj === null) {
-        return null;
+    if (obj == null) {
+        return obj;
     } else if (Array.isArray(obj)) {
         return obj.slice();
-    } else {
+    } else if (typeof obj === 'object') {
         var copy = {};
         Object.keys(obj).forEach(function (k) {
             copy[k] = obj[k];
         });
         return copy;
+    } else {
+        return obj;
     }
 }
 


### PR DESCRIPTION
Looks to be related to #198, #150, and #100. For non-object values, null, or undefined (loose `==` checking) it simply returns that value rather than trying to call Object.keys and crashing. May alternately be better to use a dedicated module, like lodash, for cloning, as the full process of creating a true replica is [rather extensive](https://github.com/lodash/lodash/blob/2.4.1/dist/lodash.compat.js#L1023-L1101).
