### PR TITLE
Standard err serializer: better support for caused errors

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -272,15 +272,8 @@ function Logger(options, _childOptions, _childSimple) {
     if (!options) {
         throw new TypeError('options (object) is required');
     }
-    if (!parent) {
-        if (!options.name) {
-            throw new TypeError('options.name (string) is required');
-        }
-    } else {
-        if (options.name) {
-            throw new TypeError(
-                'invalid options.name: child cannot set logger name');
-        }
+    if (!parent && !options.name) {
+        throw new TypeError('options.name (string) is required');
     }
     if (options.stream && options.streams) {
         throw new TypeError('cannot mix "streams" and "stream" options');


### PR DESCRIPTION
I've made some tiny changes that make the default `err` serializer support a wider range of caused errors, namely also those that have a `cause` property. I have also changed a little bit the connecting message in the full error stack to integrate better with the default stack trace formatter.

Thank you.
