### PR TITLE
Fix unavailable-RotatingFileStream at the browser

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1088,7 +1088,11 @@ function safeCycles() {
 /**
  * XXX
  */
-if (mv) {
+if (!mv) {
+    RotatingFileStream = null
+}
+else
+{
 
 function RotatingFileStream(options) {
     this.path = options.path;


### PR DESCRIPTION
RotatingFileStream is not defined when using bunyan with browserify, and Firefox (at least 35 and 36) complain. This pull request fixes this.

This should solve #231 and #223.