### PR TITLE
Unhide RotatingFileStream behind `if` conditionals

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1085,11 +1085,6 @@ function safeCycles() {
 }
 
 
-/**
- * XXX
- */
-if (mv) {
-
 function RotatingFileStream(options) {
     this.path = options.path;
     this.stream = fs.createWriteStream(this.path,
@@ -1355,9 +1350,6 @@ RotatingFileStream.prototype.destroySoon = function destroySoon(s) {
     this.stream.destroySoon();
 };
 
-} /* if (mv) */
-
-
 
 /**
  * RingBuffer is a Writable Stream that just stores the last N records in
@@ -1426,7 +1418,7 @@ module.exports.createLogger = function createLogger(options) {
 };
 
 module.exports.RingBuffer = RingBuffer;
-module.exports.RotatingFileStream = RotatingFileStream;
+module.exports.RotatingFileStream = mv ? RotatingFileStream : null;
 
 // Useful for custom `type == 'raw'` streams that may do JSON stringification
 // of log records themselves. Usage:


### PR DESCRIPTION
Defining RotatingFileStream constructor behind ```If``` conditional, fails in ```strict``` mode, `firefox` & `browserify`. See #231, #223 & #236