### PR TITLE
Only export RotatingFileStream if module "mv" is present.

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1426,7 +1426,9 @@ module.exports.createLogger = function createLogger(options) {
 };
 
 module.exports.RingBuffer = RingBuffer;
-module.exports.RotatingFileStream = RotatingFileStream;
+if (mv) {
+    module.exports.RotatingFileStream = RotatingFileStream;
+}
 
 // Useful for custom `type == 'raw'` streams that may do JSON stringification
 // of log records themselves. Usage:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "a JSON logging library for node.js services",
   "author": "Trent Mick <trentm@gmail.com> (http://trentm.com)",
   "main": "./lib/bunyan.js",


### PR DESCRIPTION
Hi,

when using bunyan under [Nodyn](http://nodyn.io/) it throws an reference-error. Wrapping the export for RotatingFileStream like the hole class (lines above), solves this issue.

Regards,
Christian