### PR TITLE
Upgrade to dtrace-provider 0.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "// comment1": "'dtrace-provider' required for dtrace features",
   "// comment2": "'mv' required for RotatingFileStream",
   "optionalDependencies": {
-    "dtrace-provider": "~0.4",
+    "dtrace-provider": "~0.5",
     "mv": "~2",
     "safe-json-stringify": "~1"
   },


### PR DESCRIPTION
Fixes #258.

Test results on iojs 1.8.1 with current master, and iojs 2.1.0 with this patch are the same. (I have 3 unrelated failures.)