### PR TITLE
Combine parent child serializer.

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -80,14 +80,23 @@ function objCopy(obj) {
     } else if (Array.isArray(obj)) {
         return obj.slice();
     } else if (typeof (obj) === 'object') {
-        var copy = {};
-        Object.keys(obj).forEach(function (k) {
-            copy[k] = obj[k];
-        });
-        return copy;
+        return copyProperties({}, obj);
     } else {
         return obj;
     }
+}
+
+/**
+ * Copy properties from src to dst; src overrides dst.
+ */
+function copyProperties(dst, src) {
+    if (dst == null || src == null) {
+        return dst;
+    }
+    Object.keys(src).forEach(function (k) {
+        dst[k] = src[k];
+    });
+    return dst;
 }
 
 var format = util.format;
@@ -332,7 +341,9 @@ function Logger(options, _childOptions, _childSimple) {
 
         this._level = parent._level;
         this.streams = parent.streams;
-        this.serializers = parent.serializers;
+        if (parent.serializers) {
+            self.addSerializers(parent.serializers);
+        }
         this.src = parent.src;
         var fields = this.fields = {};
         var parentFieldNames = Object.keys(parent.fields);
@@ -358,7 +369,9 @@ function Logger(options, _childOptions, _childSimple) {
             s.closeOnExit = false; // Don't own parent stream.
             this.streams.push(s);
         }
-        this.serializers = objCopy(parent.serializers);
+        if (parent.serializers) {
+            self.addSerializers(parent.serializers);
+        }
         this.src = parent.src;
         this.fields = objCopy(parent.fields);
         if (options.level) {
@@ -569,13 +582,26 @@ Logger.prototype.addSerializers = function addSerializers(serializers) {
     }
     Object.keys(serializers).forEach(function (field) {
         var serializer = serializers[field];
-        if (typeof (serializer) !== 'function') {
+        if (!Array.isArray(serializer) && typeof (serializer) !== 'function') {
+          throw new TypeError(format(
+              'invalid serializer for "%s" field: must be a function',
+              field));
+        }
+        if (typeof (serializer) === 'function') {
+          serializer = [ serializer ];
+        }
+        // validation
+        for (var i = 0; i < serializer.length; ++i) {
+          if (typeof(serializer[i]) !== 'function') {
             throw new TypeError(format(
                 'invalid serializer for "%s" field: must be a function',
                 field));
-        } else {
-            self.serializers[field] = serializer;
+          }
         }
+        if (!self.serializers[field]) {
+            self.serializers[field] = [];
+        }
+        self.serializers[field] = self.serializers[field].concat(serializer);
     });
 }
 
@@ -792,7 +818,18 @@ Logger.prototype._applySerializers = function (fields, excludeFields) {
         }
         xxx('_applySerializers; apply to "%s" key', name)
         try {
-            fields[name] = self.serializers[name](fields[name]);
+            var value;
+            var serializers = self.serializers[name];
+            for ( var i = 0; i < serializers.length; ++i) {
+                var serializer = serializers[i];
+                var serialized = serializer(fields[name]);
+                if (value === undefined || typeof(value) !== typeof(serialized) || Array.isArray(serialized) || typeof(serialized) !== 'object') {
+                    value = serialized;
+                } else {
+                    value = copyProperties(value, serialized);
+                }
+            }
+            fields[name] = value;
         } catch (err) {
             _warn(format('bunyan: ERROR: Exception thrown from the "%s" '
                 + 'Bunyan serializer. This should never happen. This is a bug'
@@ -878,12 +915,17 @@ function mkLogEmitter(minLevel) {
             var excludeFields;
             if (args[0] instanceof Error) {
                 // `log.<level>(err, ...)`
-                fields = {
-                    // Use this Logger's err serializer, if defined.
-                    err: (log.serializers && log.serializers.err
-                        ? log.serializers.err(args[0])
-                        : Logger.stdSerializers.err(args[0]))
-                };
+                if (log.serializers && log.serializers.err) {
+                  fields = {
+                    err: args[0]
+                  };
+                  log._applySerializers(fields);
+                }
+                else {
+                  fields = {
+                    err: Logger.stdSerializers.err(args[0])
+                  };
+                }
                 excludeFields = {err: true};
                 if (args.length === 1) {
                     msgArgs = [fields.err.message];


### PR DESCRIPTION
Extend child serializer to merge serialized data for parent serializer with same fields.

Currently, child serializer for specific fields will override the parent serializer.  This prevents custom serialization at parent level.
Parent:
```
        serializers: {
            req: function (req) {
              return {
                username: req.user.username
              };
            }
        }
```
Child:
```
        serializers: {
            req: function (req) {
              return {
                // other fields: timers, stats, etc
              };
            }
        }
```
Primary use case is restify audit logger.  
The proposed changes applies the serializers from parent and child, and merge the serialized result preferring the data from the child if there are field collision (similar to a simple `_.merge).  If there happens to be a clash in field names, the fix would be to change the field name for the serializer in the parent.
