### PR TITLE
Bump dtrace-provider to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "// comment1": "'dtrace-provider' required for dtrace features",
   "// comment2": "'mv' required for RotatingFileStream",
   "optionalDependencies": {
-    "dtrace-provider": "~0.4",
+    "dtrace-provider": "~0.5",
     "mv": "~2",
     "safe-json-stringify": "~1"
   },


### PR DESCRIPTION
This allows the module to work with iojs and electron.