### PR TITLE
Document what the standard serializers are.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Or this:
         serializers: {req: bunyan.stdSerializers.req}
     });
 
-because Bunyan includes a small set of standard serializers. To use all the
+because Bunyan includes a small set of standard serializers, including serializers for Error objects using the `error` key, and `request` and `response` objects using the `req` and `res` keys. To use all these
 standard serializers you can use:
 
     var log = bunyan.createLogger({


### PR DESCRIPTION
Using these serializers are documented in "best practices", but it was not explicitly documented in the *Serializers* section what exactly `stdSerializers` provided.