### PR TITLE
Avoid stringify if no stream will log the message.

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -829,7 +829,7 @@ Logger.prototype._emit = function (rec, noemit) {
 
     // Stringify the object. Attempt to warn/recover on error.
     var str;
-    if (noemit || this.haveNonRawStreams) {
+    if (noemit || (this.haveNonRawStreams && requiredLogLevel(rec.level, this.streams))) {
         try {
             str = JSON.stringify(rec, safeCycles()) + '\n';
         } catch (e) {
@@ -860,9 +860,28 @@ Logger.prototype._emit = function (rec, noemit) {
                 rec.msg, s.type, s.level, level, rec);
             s.stream.write(s.raw ? rec : str);
         }
-    };
+    }
 
     return str;
+}
+
+
+/**
+ * Returns true if any of the configured streams is equal or lower than the desired log level
+ * @param level {Number} Log level value
+ * @param streams {Array} List of streams
+ */
+function requiredLogLevel(level, streams) {
+    var i;
+
+    for (i = 0; i < streams.length; i++) {
+        var s = streams[i];
+        if (s.level <= level) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 


### PR DESCRIPTION
This saves an unnecessary `JSON.stringify` and string concatenation if no non-raw stream will actually log the message due to the configured log levels.