### PR TITLE
Export the RotatingFileStream only when it's defined. 

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1426,7 +1426,12 @@ module.exports.createLogger = function createLogger(options) {
 };
 
 module.exports.RingBuffer = RingBuffer;
-module.exports.RotatingFileStream = RotatingFileStream;
+
+// Only export RotatingFileStream if it's defined
+// This only applies in the browser where it causes a fatal crash
+if (mv) {
+    module.exports.RotatingFileStream = RotatingFileStream;
+}
 
 // Useful for custom `type == 'raw'` streams that may do JSON stringification
 // of log records themselves. Usage:


### PR DESCRIPTION
Fix a problem that lead to a fatal crash in firefox because of this null reference.
https://github.com/trentm/node-bunyan/issues/223
