### PR TITLE
Allow 'time' field to be set with user function

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -321,7 +321,10 @@ function Logger(options, _childOptions, _childSimple) {
             Array.isArray(options.serializers))) {
         throw new TypeError('invalid options.serializers: must be an object')
     }
-
+    if (options.time && (typeof (options.time) !== 'function')) {
+        throw new TypeError('invalid options.time: must be a function');
+    }
+    
     EventEmitter.call(this);
 
     // Fast path for simple child creation.
@@ -334,6 +337,7 @@ function Logger(options, _childOptions, _childSimple) {
         this.streams = parent.streams;
         this.serializers = parent.serializers;
         this.src = parent.src;
+        this.time = parent.time;
         var fields = this.fields = {};
         var parentFieldNames = Object.keys(parent.fields);
         for (var i = 0; i < parentFieldNames.length; i++) {
@@ -360,6 +364,7 @@ function Logger(options, _childOptions, _childSimple) {
         }
         this.serializers = objCopy(parent.serializers);
         this.src = parent.src;
+        this.time = parent.time;
         this.fields = objCopy(parent.fields);
         if (options.level) {
             this.level(options.level);
@@ -369,6 +374,7 @@ function Logger(options, _childOptions, _childSimple) {
         this.streams = [];
         this.serializers = null;
         this.src = false;
+        this.time = false;
         this.fields = {};
     }
 
@@ -433,6 +439,9 @@ function Logger(options, _childOptions, _childSimple) {
     if (options.src) {
         this.src = true;
     }
+    if (options.time) {
+        this.time = options.time;
+    }
     xxx('Logger: ', self)
 
     // Fields.
@@ -446,6 +455,7 @@ function Logger(options, _childOptions, _childSimple) {
     delete fields.streams;
     delete fields.serializers;
     delete fields.src;
+    delete fields.time;
     if (this.serializers) {
         this._applySerializers(fields);
     }
@@ -919,8 +929,12 @@ function mkLogEmitter(minLevel) {
                 });
             }
             rec.msg = format.apply(log, msgArgs);
+            // Set time of log entry (use user function if provided) 
             if (!rec.time) {
-                rec.time = (new Date());
+                if (log.time)
+                    rec.time = (log.time)();
+                else
+                    rec.time = (new Date());
             }
             // Get call source info
             if (log.src && !rec.src) {


### PR DESCRIPTION
I love the bunyan library, but it has always been troubling to me that the time is recorded in the log files as UTC time, to the millisecond. I would much rather be able to provide a function (passed in using options.time) that formats the time how I would like. This would allow log file timestamps to be read much more easily by human users. We already have this functionality in the CLI tool, so why not here?

I did everything to stick to the current API which says to set the 'time' property, but found it too cumbersome, especially because if you pass in more than one parameter to the logging function, only the first parameter's object properties will be added as fields of the logging object (the rest will be stringified into the 'msg' field). For example if I do `log.error(new Error('The system crashed.'), {time: myTimeFunction()});`, the time will no longer be added as a field of the log record; if I switch the parameters, unfortunately, the Error will no longer be logged with its stack trace since it is stringified into the 'msg' field instead of being serialized by Bunyan. This minor code addition is the best way I see to allow user-specified time formats without sacrificing logger functionality. Please consider this issue, and if you would rather implement it in another way that is also ok, but let's find something that'll work in these sorts of instances! Thanks in advance!

Example usage:

    ...
    var logger = bunyan.createLogger({name: 'mylogger', streams: myStreamsObject, time: function() {
        return (new Date()).toLocaleString();
    });
    ...
    logger.info('example output');    //behaves same as expected