### PR TITLE
Add rotation of log files by size.  Configuration requires user to pr…

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1102,6 +1102,9 @@ function RotatingFileStream(options) {
         format('rotating-file stream "count" is not >= 0: %j in %j',
             this.count, this));
 
+    assert.ok((options.period && !options.size) || (!options.period && options.size),
+        format('period and size setting on rotating-file are mutually exclusive'));
+
     // Parse `options.period`.
     if (options.period) {
         // <number><scope> where scope is:
@@ -1125,6 +1128,8 @@ function RotatingFileStream(options) {
         }
         this.periodNum = Number(m[1]);
         this.periodScope = m[2];
+    } else if (options.size) {
+        this.rotateFileSize = options.size;
     } else {
         this.periodNum = 1;
         this.periodScope = 'd';
@@ -1154,20 +1159,22 @@ function RotatingFileStream(options) {
 util.inherits(RotatingFileStream, EventEmitter);
 
 RotatingFileStream.prototype._setupNextRot = function () {
-    var self = this;
-    this.rotAt = this._nextRotTime();
-    var delay = this.rotAt - Date.now();
-    // Cap timeout to Node's max setTimeout, see
-    // <https://github.com/joyent/node/issues/8656>.
-    var TIMEOUT_MAX = 2147483647; // 2^31-1
-    if (delay > TIMEOUT_MAX) {
-        delay = TIMEOUT_MAX;
-    }
-    this.timeout = setTimeout(
-        function () { self.rotate(); },
-        delay);
-    if (typeof (this.timeout.unref) === 'function') {
-        this.timeout.unref();
+    if (this.periodNum && this.periodScope) {
+        var self = this;
+        this.rotAt = this._nextRotTime();
+        var delay = this.rotAt - Date.now();
+        // Cap timeout to Node's max setTimeout, see
+        // <https://github.com/joyent/node/issues/8656>.
+        var TIMEOUT_MAX = 2147483647; // 2^31-1
+        if (delay > TIMEOUT_MAX) {
+            delay = TIMEOUT_MAX;
+        }
+        this.timeout = setTimeout(
+            function () { self.rotate(); },
+            delay);
+        if (typeof (this.timeout.unref) === 'function') {
+            this.timeout.unref();
+        }
     }
 }
 
@@ -1258,8 +1265,10 @@ RotatingFileStream.prototype.rotate = function rotate() {
 
     // If rotation period is > ~25 days, we have to break into multiple
     // setTimeout's. See <https://github.com/joyent/node/issues/8656>.
-    if (self.rotAt && self.rotAt > Date.now()) {
-        return self._setupNextRot();
+    if (this.periodNum && this.periodScope) {
+        if (self.rotAt && self.rotAt > Date.now()) {
+            return self._setupNextRot();
+        }
     }
 
     if (_DEBUG) {
@@ -1339,7 +1348,12 @@ RotatingFileStream.prototype.write = function write(s) {
         this.rotQueue.push(s);
         return false;
     } else {
-        return this.stream.write(s);
+        if (this.stream.bytesWritten > this.rotateFileSize) {
+            this.rotate();
+            return false;
+        } else {
+            return this.stream.write(s);
+        }
     }
 };
 


### PR DESCRIPTION
…ovide only rotation by period or size - configuration by both is not allowed.  Because of the buffering done by streams, the rotation will be approximate.  This is especially true if log messages are coming in at a very high rate.