### PR TITLE
Log error and objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ full API is:
                     // message.
     log.info(err, 'more on this: %s', more);
                     // ... or you can specify the "msg".
+    log.info(err, {foo: 'bar'}, 'hi');
+    log.info({foo: 'bar'}, err, 'hi');
+                    // mix an error with additional fields
 
 Note that this implies **you cannot pass any object as the first argument
 to log it**. IOW, `log.info(mywidget)` may not be what you expect. Instead

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -876,34 +876,47 @@ function mkLogEmitter(minLevel) {
 
         function mkRecord(args) {
             var excludeFields;
-            if (args[0] instanceof Error) {
-                // `log.<level>(err, ...)`
-                fields = {
+            var err;
+            var argIdx;
+            for (argIdx = 0; argIdx < args.length; ++argIdx) {
+                var arg = args[argIdx];
+                if (arg instanceof Error) {
+                    // `log.<level>(err, ...)`
                     // Use this Logger's err serializer, if defined.
-                    err: (log.serializers && log.serializers.err
-                        ? log.serializers.err(args[0])
-                        : Logger.stdSerializers.err(args[0]))
-                };
-                excludeFields = {err: true};
-                if (args.length === 1) {
-                    msgArgs = [fields.err.message];
-                } else {
-                    msgArgs = Array.prototype.slice.call(args, 1);
+                    err = (log.serializers && log.serializers.err
+                           ? log.serializers.err(arg)
+                           : Logger.stdSerializers.err(arg));
+                    excludeFields = {err: true};
+                } else if (typeof (arg) !== 'object' && arg !== null ||
+                           Array.isArray(arg) || Buffer.isBuffer(arg)) {
+                    // `log.<level>(msg, ...)`
+                    break;
+                } else {  // `log.<level>(fields, msg, ...)`
+                    if (arg) {
+                        if (!fields)
+                            fields = {};
+                        for (var key in arg) {
+                            fields[key] = arg[key];
+                        }
+                    } else if (argIdx === args.length - 1) {
+                        // trailing `null` parameter
+                        break;
+                    }
                 }
-            } else if (typeof (args[0]) !== 'object' && args[0] !== null ||
-                       Array.isArray(args[0])) {
-                // `log.<level>(msg, ...)`
-                fields = null;
-                msgArgs = Array.prototype.slice.call(args);
-            } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
+            }
+
+            msgArgs = Array.prototype.slice.call(args, argIdx);
+            if (Buffer.isBuffer(msgArgs[0])) {  // `log.<level>(buf, ...)`
                 // Almost certainly an error, show `inspect(buf)`. See bunyan
                 // issue #35.
-                fields = null;
-                msgArgs = Array.prototype.slice.call(args);
                 msgArgs[0] = util.inspect(msgArgs[0]);
-            } else {  // `log.<level>(fields, msg, ...)`
-                fields = args[0];
-                msgArgs = Array.prototype.slice.call(args, 1);
+            }
+            if (err) {
+                if (msgArgs.length === 0)
+                    msgArgs = [err.message];
+                if (!fields)
+                    fields = {};
+                fields.err = err;
             }
 
             // Build up the record object.

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -249,3 +249,52 @@ test('log.info(<err>)', function (t) {
     });
     t.end();
 });
+
+test('log.info(<fields>, <err>)', function (t) {
+    var e = new Error('boom');
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, fields, e);
+        var rec = catcher.records[catcher.records.length - 1];
+        t.equal(rec.err.message, 'boom',
+            format('log.%s err.message: got %j', lvl, rec.err.message));
+        t.equal(rec.one, 'un');
+    });
+    t.end();
+});
+
+test('log.info(<err>, <fields>)', function (t) {
+    var e = new Error('boom');
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, e, fields);
+        var rec = catcher.records[catcher.records.length - 1];
+        t.equal(rec.err.message, 'boom',
+            format('log.%s err.message: got %j', lvl, rec.err.message));
+        t.equal(rec.one, 'un');
+    });
+    t.end();
+});
+
+test('log.info(<fields>, <fields>)', function (t) {
+    var e = new Error('boom');
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, fields, {two: 'deux'});
+        var rec = catcher.records[catcher.records.length - 1];
+        t.equal(rec.one, 'un');
+        t.equal(rec.two, 'deux');
+    });
+    t.end();
+});
+
+test('log.info(<err>, <fields>, <msg>)', function (t) {
+    var e = new Error('boom');
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, e, fields, 'some message');
+        var rec = catcher.records[catcher.records.length - 1];
+        t.equal(rec.err.message, 'boom',
+            format('log.%s err.message: got %j', lvl, rec.err.message));
+        t.equal(rec.msg, 'some message',
+            format('log.%s msg is "some message"', lvl));
+        t.equal(rec.one, 'un');
+    });
+    t.end();
+});


### PR DESCRIPTION
This allows to log an error with additional fields. You can use both `log.info(err, fields...)` and `log.info(fields, err...)`.
