### PR TITLE
child inherit hostname

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -449,7 +449,8 @@ function Logger(options, _childOptions, _childSimple) {
     if (this.serializers) {
         this._applySerializers(fields);
     }
-    if (!fields.hostname) {
+    //if child mode, hostname might be inherited
+    if (!fields.hostname && ! self.fields.hostname) {
         fields.hostname = os.hostname();
     }
     if (!fields.pid) {


### PR DESCRIPTION
check if fields.hostname is already set before applying fallback

this ensures that sub loggers do not lose parent given hostname

replaces #229 