### PR TITLE
Fix bug where UTC offset is displayed on localtime

### DIFF
--- a/bin/bunyan
+++ b/bin/bunyan
@@ -763,6 +763,7 @@ function emitRecord(rec, line, opts, stylize) {
             }
             time = new Date(
                 (new Date(time)).getTime() - timezoneOffsetMs).toISOString()
+            time = time.slice(0,-1);
             break;
         }
         if (short && rec.time[10] === 'T') {


### PR DESCRIPTION
Partially addresses Issue #245 by slicing off the "Z" at the end of the ISO string when in display localtime mode. 

According to the the ISO-8601 spec, without any identifier, the timezone is assumed to be in local time. See, e.g., https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators ("If no UTC relation information is given with a time representation, the time is assumed to be in local time.").


