### PR TITLE
Upgrade to dtrace-provider 0.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "// comment1": "'dtrace-provider' required for dtrace features",
   "// comment2": "'mv' required for RotatingFileStream",
   "optionalDependencies": {
-    "dtrace-provider": "~0.5",
+    "dtrace-provider": "~0.6",
     "mv": "~2",
     "safe-json-stringify": "~1"
   },


### PR DESCRIPTION
The new dtrace-provider release should fix issues on io.js 3.x and beyond. \o/

See: https://github.com/chrisa/node-dtrace-provider/pull/68

I believe this should also fix: https://github.com/trentm/node-bunyan/issues/284

Tests pass on OS X 10.10.5, and I tested it with our own app. No more funky startup errors. :-)