### PR TITLE
Bump dtrace-provider to 0.6.0 to fix build on iojs 3.0.0 and node 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "// comment1": "'dtrace-provider' required for dtrace features",
   "// comment2": "'mv' required for RotatingFileStream",
   "optionalDependencies": {
-    "dtrace-provider": "~0.5",
+    "dtrace-provider": "~0.6.0",
     "mv": "~2",
     "safe-json-stringify": "~1"
   },


### PR DESCRIPTION
Trying to get all my dependancies ready for Node 4.0.0 :)