### PR TITLE
Changing check for window to check for node instead

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -26,7 +26,7 @@ var xxx = function xxx(s) {     // internal dev/debug logging
 var xxx = function xxx() {};  // comment out to turn on debug logging
 
 
-if (typeof (window) === 'undefined') {
+if (typeof (global) === 'object') {
     var os = require('os');
     var fs = require('fs');
     try {


### PR DESCRIPTION
Allows the module to be used in NW.js / Electron.

The tests still pass. I don't know if there's any more I need to do. Have a look at the makefile but that's gibberish to me.

Fixes #301 