### PR TITLE
Use process.browser instead of checking for window

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -25,8 +25,8 @@ var xxx = function xxx(s) {     // internal dev/debug logging
 };
 var xxx = function xxx() {};  // comment out to turn on debug logging
 
-
-if (typeof (window) === 'undefined') {
+/* in browserify, process.browser == true */
+if (!process.browser) {
     var os = require('os');
     var fs = require('fs');
     try {
@@ -64,10 +64,6 @@ try {
 } catch (e) {
     mv = null;
 }
-
-// Are we in the browser (e.g. running via browserify)?
-var isBrowser = function () {
-        return typeof (window) !== 'undefined'; }();
 
 try {
     /* Use `+ ''` to hide this import from browserify. */
@@ -418,7 +414,8 @@ function Logger(options, _childOptions, _childSimple) {
     } else if (parent && options.level) {
         this.level(options.level);
     } else if (!parent) {
-        if (isBrowser) {
+        /* in browserify, process.browser == true */
+        if (process.browser) {
             /*
              * In the browser we'll be emitting to console.log by default.
              * Any console.log worth its salt these days can nicely render


### PR DESCRIPTION
The browserify version of [process][1] sets `process.browser = true` that we can use instead of checking for the existence of `window`. This plays nice with transforms like [bpb][2] that replace `process.browser` with a constant which enables unreachable code branches to be removed during bundling. I don't have first-hand experience with nw.js but the project says it has [complete support for all Node.js APIs][3] so this should also fix #301 /cc @amoussard @fleg @adam-lynch.

[1]: https://www.npmjs.com/package/process#browser-implementation
[2]: https://github.com/zenflow/bpb
[3]: https://github.com/nwjs/nw.js/#features