### PR TITLE
Any stream with an on function will register for error

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -532,9 +532,6 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
         if (!s.stream) {
             s.stream = fs.createWriteStream(s.path,
                                             {flags: 'a', encoding: 'utf8'});
-            s.stream.on('error', function (err) {
-                self.emit('error', err, s);
-            });
             if (!s.closeOnExit) {
                 s.closeOnExit = true;
             }
@@ -564,6 +561,11 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
         throw new TypeError('unknown stream type "' + s.type + '"');
     }
 
+    if(typeof s.stream.on === 'function') {
+        s.stream.on('error', function (err) {
+            self.emit('error', err, s);
+        });
+    }
     self.streams.push(s);
     delete self.haveNonRawStreams;  // reset
 }


### PR DESCRIPTION
Hi,

Bunyan forwards handles stream errors for files although the [documentation](https://github.com/trentm/node-bunyan#stream-errors)  does not indicate this is expected. This patch fixes that if the type is a function to ensure backwards compatibility. Specifically, this is very useful for a custom raw stream.

Thanks,
Marc