### PR TITLE
Added support for callback after stream write.

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -870,17 +870,15 @@ Logger.prototype._emit = function (rec, noemit) {
     for (i = 0; i < this.streams.length; i++) {
         var s = this.streams[i];
         if (s.level <= level) {
-          xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
-              rec.msg, s.type, s.level, level, rec);
-          s.stream.write(
-            s.raw ? rec : str,
-            rec.hasOwnProperty('callback') ? rec.callback : undefined
-          );
+            xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
+                rec.msg, s.type, s.level, level, rec);
+            s.stream.write(s.raw ? rec : str);
         }
     };
 
     return str;
 }
+
 
 /**
  * Build a log emitter function for level minLevel. I.e. this is the
@@ -890,15 +888,8 @@ function mkLogEmitter(minLevel) {
     return function () {
         var log = this;
 
-        function mkRecord(mkArgs) {
+        function mkRecord(args) {
             var excludeFields;
-            var args = Array.prototype.slice.call(mkArgs);
-            if (args.length > 1) {
-              // is last arg a function ? if so remove from args
-              if (typeof (args[args.length - 1]) === 'function') {
-                var callback = args.pop();
-              }
-            }
             if (args[0] instanceof Error) {
                 // `log.<level>(err, ...)`
                 fields = {
@@ -911,22 +902,22 @@ function mkLogEmitter(minLevel) {
                 if (args.length === 1) {
                     msgArgs = [fields.err.message];
                 } else {
-                    msgArgs = args.slice(1);
+                    msgArgs = Array.prototype.slice.call(args, 1);
                 }
             } else if (typeof (args[0]) !== 'object' && args[0] !== null ||
                        Array.isArray(args[0])) {
                 // `log.<level>(msg, ...)`
                 fields = null;
-                msgArgs = args.slice();
+                msgArgs = Array.prototype.slice.call(args);
             } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
                 // Almost certainly an error, show `inspect(buf)`. See bunyan
                 // issue #35.
                 fields = null;
-                msgArgs = args.slice();
+                msgArgs = Array.prototype.slice.call(args);
                 msgArgs[0] = util.inspect(msgArgs[0]);
             } else {  // `log.<level>(fields, msg, ...)`
                 fields = args[0];
-                msgArgs = args.slice(1);
+                msgArgs = Array.prototype.slice.call(args, 1);
             }
 
             // Build up the record object.
@@ -950,7 +941,6 @@ function mkLogEmitter(minLevel) {
                 rec.src = getCaller3Info()
             }
             rec.v = LOG_VERSION;
-            if (typeof (callback) !== 'undefined') rec.callback = callback;
 
             return rec;
         };
@@ -990,6 +980,7 @@ function mkLogEmitter(minLevel) {
         });
     }
 }
+
 
 /**
  * The functions below log a record at a specific level.

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -870,15 +870,17 @@ Logger.prototype._emit = function (rec, noemit) {
     for (i = 0; i < this.streams.length; i++) {
         var s = this.streams[i];
         if (s.level <= level) {
-            xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
-                rec.msg, s.type, s.level, level, rec);
-            s.stream.write(s.raw ? rec : str);
+          xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
+              rec.msg, s.type, s.level, level, rec);
+          s.stream.write(
+            s.raw ? rec : str,
+            rec.hasOwnProperty('callback') ? rec.callback : undefined
+          );
         }
     };
 
     return str;
 }
-
 
 /**
  * Build a log emitter function for level minLevel. I.e. this is the
@@ -888,8 +890,15 @@ function mkLogEmitter(minLevel) {
     return function () {
         var log = this;
 
-        function mkRecord(args) {
+        function mkRecord(mkArgs) {
             var excludeFields;
+            var args = Array.prototype.slice.call(mkArgs);
+            if (args.length > 1) {
+              // is last arg a function ? if so remove from args
+              if (typeof (args[args.length - 1]) === 'function') {
+                var callback = args.pop();
+              }
+            }
             if (args[0] instanceof Error) {
                 // `log.<level>(err, ...)`
                 fields = {
@@ -902,22 +911,22 @@ function mkLogEmitter(minLevel) {
                 if (args.length === 1) {
                     msgArgs = [fields.err.message];
                 } else {
-                    msgArgs = Array.prototype.slice.call(args, 1);
+                    msgArgs = args.slice(1);
                 }
             } else if (typeof (args[0]) !== 'object' && args[0] !== null ||
                        Array.isArray(args[0])) {
                 // `log.<level>(msg, ...)`
                 fields = null;
-                msgArgs = Array.prototype.slice.call(args);
+                msgArgs = args.slice();
             } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
                 // Almost certainly an error, show `inspect(buf)`. See bunyan
                 // issue #35.
                 fields = null;
-                msgArgs = Array.prototype.slice.call(args);
+                msgArgs = args.slice();
                 msgArgs[0] = util.inspect(msgArgs[0]);
             } else {  // `log.<level>(fields, msg, ...)`
                 fields = args[0];
-                msgArgs = Array.prototype.slice.call(args, 1);
+                msgArgs = args.slice(1);
             }
 
             // Build up the record object.
@@ -941,6 +950,7 @@ function mkLogEmitter(minLevel) {
                 rec.src = getCaller3Info()
             }
             rec.v = LOG_VERSION;
+            if (typeof (callback) !== 'undefined') rec.callback = callback;
 
             return rec;
         };
@@ -980,7 +990,6 @@ function mkLogEmitter(minLevel) {
         });
     }
 }
-
 
 /**
  * The functions below log a record at a specific level.

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -870,9 +870,12 @@ Logger.prototype._emit = function (rec, noemit) {
     for (i = 0; i < this.streams.length; i++) {
         var s = this.streams[i];
         if (s.level <= level) {
-            xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
-                rec.msg, s.type, s.level, level, rec);
-            s.stream.write(s.raw ? rec : str);
+          xxx('writing log rec "%s" to "%s" stream (%d <= %d): %j',
+              rec.msg, s.type, s.level, level, rec);
+          s.stream.write(
+            s.raw ? rec : str,
+            rec.hasOwnProperty('callback') ? rec.callback : undefined
+          );
         }
     };
 
@@ -888,8 +891,15 @@ function mkLogEmitter(minLevel) {
     return function () {
         var log = this;
 
-        function mkRecord(args) {
+        function mkRecord(mkArgs) {
             var excludeFields;
+            var args = Array.prototype.slice.call(mkArgs);
+            if (args.length > 1) {
+              // is last arg a function ? if so remove from args
+              if (typeof (args[args.length - 1]) === 'function') {
+                var callback = args.pop();
+              }
+            }
             if (args[0] instanceof Error) {
                 // `log.<level>(err, ...)`
                 fields = {
@@ -902,22 +912,22 @@ function mkLogEmitter(minLevel) {
                 if (args.length === 1) {
                     msgArgs = [fields.err.message];
                 } else {
-                    msgArgs = Array.prototype.slice.call(args, 1);
+                    msgArgs = args.slice(1);
                 }
             } else if (typeof (args[0]) !== 'object' && args[0] !== null ||
                        Array.isArray(args[0])) {
                 // `log.<level>(msg, ...)`
                 fields = null;
-                msgArgs = Array.prototype.slice.call(args);
+                msgArgs = args.slice();
             } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
                 // Almost certainly an error, show `inspect(buf)`. See bunyan
                 // issue #35.
                 fields = null;
-                msgArgs = Array.prototype.slice.call(args);
+                msgArgs = args.slice();
                 msgArgs[0] = util.inspect(msgArgs[0]);
             } else {  // `log.<level>(fields, msg, ...)`
                 fields = args[0];
-                msgArgs = Array.prototype.slice.call(args, 1);
+                msgArgs = args.slice(1);
             }
 
             // Build up the record object.
@@ -941,6 +951,7 @@ function mkLogEmitter(minLevel) {
                 rec.src = getCaller3Info()
             }
             rec.v = LOG_VERSION;
+            if (typeof (callback) !== 'undefined') rec.callback = callback;
 
             return rec;
         };

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -209,9 +209,10 @@ test('log.info(<fields>, <function>)', function (t) {
     names.forEach(function (lvl) {
         log3[lvl].call(log3, fields, func);
         var rec = catcher.records[catcher.records.length - 1];
-        t.equal(rec.msg, '[Function: func2]',
+        t.equal(rec.msg, '',
             format('log.%s msg: got %j', lvl, rec.msg));
         t.equal(rec.one, 'un');
+        t.afterEach()
     });
     t.end();
 });

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -209,7 +209,7 @@ test('log.info(<fields>, <function>)', function (t) {
     names.forEach(function (lvl) {
         log3[lvl].call(log3, fields, func);
         var rec = catcher.records[catcher.records.length - 1];
-        t.equal(rec.msg, '[Function: func2]',
+        t.equal(rec.msg, '',
             format('log.%s msg: got %j', lvl, rec.msg));
         t.equal(rec.one, 'un');
     });

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -209,10 +209,9 @@ test('log.info(<fields>, <function>)', function (t) {
     names.forEach(function (lvl) {
         log3[lvl].call(log3, fields, func);
         var rec = catcher.records[catcher.records.length - 1];
-        t.equal(rec.msg, '',
+        t.equal(rec.msg, '[Function: func2]',
             format('log.%s msg: got %j', lvl, rec.msg));
         t.equal(rec.one, 'un');
-        t.afterEach()
     });
     t.end();
 });


### PR DESCRIPTION
Added support for callback after stream write. Ran into this when trying to write a log message just before killing the process.

Example - 
```
client.on('error', function (err) { 
  log.fatal(err, function () { process.exit(1) }); 
} 
```

I'm a bit unsure of how to use the testing framework to check the result of the callback. For now I made a change at line 212 to reflect the fact that the result is now an empty string.