### PR TITLE
Don't start file delete/move until rotating stream has ended properly

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1284,8 +1284,6 @@ RotatingFileStream.prototype.rotate = function rotate() {
     }
     self.rotating = true;
 
-    self.stream.end();  // XXX can do moves sync after this? test at high rate
-
     function del() {
         var toDel = self.path + '.' + String(n - 1);
         if (n === 0) {
@@ -1344,7 +1342,9 @@ RotatingFileStream.prototype.rotate = function rotate() {
     }
 
     var n = this.count;
-    del();
+    self.stream.end(function () {
+        del();
+    });
 };
 
 RotatingFileStream.prototype.write = function write(s) {


### PR DESCRIPTION
Happy to see this project is still alive! I've been using a patched version that correctly handles rotations (issue #344) for about a month now, and it's been working well. This pull request fixes a minor issue I also came across.
