### PR TITLE
Don't advance to next rotation time when timeout fires early

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Known issues:
 
 - Update `make test` to test against node 5, 4, 0.12 and 0.10.
 
+- [issue #344 ] Fix log rotation failures for periods > approx. 25 days.
+
 
 ## 1.5.1
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1181,14 +1181,13 @@ RotatingFileStream = function RotatingFileStream(options) {
 
 util.inherits(RotatingFileStream, EventEmitter);
 
-RotatingFileStream.prototype._setupNextRot = function (timerWasExtended) {
-    // Optional parameter timerWasExtended denotes that the timeout fired before
-    // the rotation time was reached, and therefore the next rotation time
-    // should not be advanced.
+RotatingFileStream.prototype._setupNextRot = function () {
+    this.rotAt = this._nextRotTime();
+    this._setRotationTimer();
+}
+
+RotatingFileStream.prototype._setRotationTimer = function () {
     var self = this;
-    if (!timerWasExtended) {
-      this.rotAt = this._nextRotTime();
-    }
     var delay = this.rotAt - Date.now();
     // Cap timeout to Node's max setTimeout, see
     // <https://github.com/joyent/node/issues/8656>.
@@ -1292,7 +1291,7 @@ RotatingFileStream.prototype.rotate = function rotate() {
     // If rotation period is > ~25 days, we have to break into multiple
     // setTimeout's. See <https://github.com/joyent/node/issues/8656>.
     if (self.rotAt && self.rotAt > Date.now()) {
-        return self._setupNextRot(true); // true: don't advance rotation time
+        return self._setRotationTimer();
     }
 
     if (_DEBUG) {

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1181,9 +1181,14 @@ RotatingFileStream = function RotatingFileStream(options) {
 
 util.inherits(RotatingFileStream, EventEmitter);
 
-RotatingFileStream.prototype._setupNextRot = function () {
+RotatingFileStream.prototype._setupNextRot = function (timerWasExtended) {
+    // Optional parameter timerWasExtended denotes that the timeout fired before
+    // the rotation time was reached, and therefore the next rotation time
+    // should not be advanced.
     var self = this;
-    this.rotAt = this._nextRotTime();
+    if (!timerWasExtended) {
+      this.rotAt = this._nextRotTime();
+    }
     var delay = this.rotAt - Date.now();
     // Cap timeout to Node's max setTimeout, see
     // <https://github.com/joyent/node/issues/8656>.
@@ -1287,7 +1292,7 @@ RotatingFileStream.prototype.rotate = function rotate() {
     // If rotation period is > ~25 days, we have to break into multiple
     // setTimeout's. See <https://github.com/joyent/node/issues/8656>.
     if (self.rotAt && self.rotAt > Date.now()) {
-        return self._setupNextRot();
+        return self._setupNextRot(true); // true: don't advance rotation time
     }
 
     if (_DEBUG) {


### PR DESCRIPTION
Fixes issue #344. Previous pull request was closed by GitHub for some reason (the branch changed but the commit was still there).