### PR TITLE
Handle requests forwarded by proxies

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1040,7 +1040,7 @@ Logger.stdSerializers.req = function req(req) {
         url: req.url,
         headers: req.headers,
         remoteAddress: req.headers['x-forwarded-for'] || req.connection.remoteAddress,
-        remotePort: req.connection.remotePort
+        remotePort: req.headers['x-forwarded-port'] || req.connection.remotePort
     };
     // Trailers: Skipping for speed. If you need trailers in your app, then
     // make a custom serializer.

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1039,7 +1039,7 @@ Logger.stdSerializers.req = function req(req) {
         method: req.method,
         url: req.url,
         headers: req.headers,
-        remoteAddress: req.connection.remoteAddress,
+        remoteAddress: req.headers['x-forwarded-for'] || req.connection.remoteAddress,
         remotePort: req.connection.remotePort
     };
     // Trailers: Skipping for speed. If you need trailers in your app, then


### PR DESCRIPTION
This pull-request overrides the HTTP request's `remoteAddress` and `remotePort` values with the ones specified by the forwarding proxy server present in the HTTP headers. Mapping:
- `remoteAddress` -> `X-Forwarded-For`
- `remotePort` -> `X-Forwarded-Port`
