### PR TITLE
Check body length to prevent empty lines

### DIFF
--- a/bin/bunyan
+++ b/bin/bunyan
@@ -972,8 +972,9 @@ function emitRecord(rec, line, opts, stylize) {
                     function (h) { return h + ': ' + headers[h]; }).join('\n');
             }
             if (res.body !== undefined) {
-                s += '\n\n' + (typeof (res.body) === 'object'
+                var body = (typeof (res.body) === 'object'
                     ? JSON.stringify(res.body, null, 2) : res.body);
+                if (body.length > 0) { s += '\n\n' + body };
                 delete res.body;
             } else {
                 s = s.trimRight();

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -502,3 +502,31 @@ test('client_req extra newlines, client_res={} (pull #252)', function (t) {
         t.end();
     });
 });
+
+test('should only show nonempty response bodies', function (t) {
+    var expect = [
+        /* BEGIN JSSTYLED */
+        '[2016-02-10T07:28:41.419Z]  INFO: myservice/123 on example.com: UnauthorizedError',
+        '    HTTP/1.1 401 Unauthorized',
+        '    content-type: text/plain',
+        '    date: Sat, 07 Mar 2015 06:58:43 GMT',
+        '[2016-02-10T07:28:41.419Z]  INFO: myservice/123 on example.com: hello',
+        '    HTTP/1.1 200 OK',
+        '    content-type: text/plain',
+        '    content-length: 0',
+        '    date: Sat, 07 Mar 2015 06:58:43 GMT',
+        '    ',
+        '    hello',
+        '[2016-02-10T07:28:41.419Z]  INFO: myservice/123 on example.com: UnauthorizedError',
+        '    HTTP/1.1 401 Unauthorized',
+        '    content-type: text/plain',
+        '    date: Sat, 07 Mar 2015 06:58:43 GMT'
+        /* END JSSTYLED */
+    ].join('\n') + '\n';
+    exec(_('%s %s/corpus/content-length-0-res.log', BUNYAN, __dirname),
+            function (err, stdout, stderr) {
+        t.ifError(err);
+        t.equal(stdout, expect);
+        t.end();
+    });
+});

--- a/test/corpus/content-length-0-res.log
+++ b/test/corpus/content-length-0-res.log
@@ -1,0 +1,3 @@
+{"name":"myservice","hostname":"example.com","pid":123,"level":30,"client_res":{"statusCode":401,"headers":{"content-type":"text/plain","date":"Sat, 07 Mar 2015 06:58:43 GMT"},"body":""},"msg":"UnauthorizedError","time":"2016-02-10T07:28:41.419Z","v":0}
+{"name":"myservice","hostname":"example.com","pid":123,"level":30,"client_res":{"statusCode":200,"headers":{"content-type":"text/plain","content-length":0,"date":"Sat, 07 Mar 2015 06:58:43 GMT"},"body":"hello"},"msg":"hello","time":"2016-02-10T07:28:41.419Z","v":0}
+{"name":"myservice","hostname":"example.com","pid":123,"level":30,"client_res":{"statusCode":401,"headers":{"content-type":"text/plain","date":"Sat, 07 Mar 2015 06:58:43 GMT"}},"msg":"UnauthorizedError","time":"2016-02-10T07:28:41.419Z","v":0}


### PR DESCRIPTION
This might do for https://github.com/trentm/node-bunyan/issues/234. I decided to check the actual body length, not the content-length billed by the headers, so we display nonempty bodies.