### PR TITLE
Fix errors when browserified version in Webkit

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1080,7 +1080,7 @@ Logger.prototype.fatal = mkLogEmitter(FATAL);
 Logger.stdSerializers = {};
 
 // Serialize an HTTP request.
-Logger.stdSerializers.req = function req(req) {
+Logger.stdSerializers.req = function stdSerializersReq(req) {
     if (!req || !req.connection)
         return req;
     return {
@@ -1098,7 +1098,7 @@ Logger.stdSerializers.req = function req(req) {
 };
 
 // Serialize an HTTP response.
-Logger.stdSerializers.res = function res(res) {
+Logger.stdSerializers.res = function stdSerializersRes(res) {
     if (!res || !res.statusCode)
         return res;
     return {
@@ -1131,7 +1131,7 @@ function getFullErrorStack(ex)
 
 // Serialize an Error object
 // (Core error properties are enumerable in node 0.4, not in 0.6).
-var errSerializer = Logger.stdSerializers.err = function err(err) {
+var errSerializer = Logger.stdSerializers.err = function stdSerializersErr(err) {
     if (!err || !err.stack)
         return err;
     var obj = {


### PR DESCRIPTION
When you're using a browserified version in Safari, for instance, and
the strict mode there is a syntax error regarding to wrong function/parameter
naming: "SyntaxError: Cannot declare a parameter named 'req' as it
shadows the name of a strict mode function". This commit fixes that.

See the attached screenshot.
<img width="748" alt="screen shot 2016-03-06 at 13 03 02" src="https://cloud.githubusercontent.com/assets/887952/13554019/0c0c5520-e39d-11e5-9e25-56657d84da44.png">
