### PR TITLE
Added support for customStringify

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -389,6 +389,10 @@ function Logger(options, _childOptions, _childSimple) {
         throw new TypeError('invalid options.serializers: must be an object')
     }
 
+    if (options.customStringify && typeof (options.customStringify) !== 'function') {
+        throw new TypeError('invalid options.customStringify: must be a function')
+    }
+
     EventEmitter.call(this);
 
     // Fast path for simple child creation.
@@ -499,6 +503,9 @@ function Logger(options, _childOptions, _childSimple) {
     }
     if (options.src) {
         this.src = true;
+    }
+    if (options.customStringify) {
+        this.customStringify = options.customStringify;
     }
     xxx('Logger: ', self)
 
@@ -907,21 +914,25 @@ Logger.prototype._emit = function (rec, noemit) {
     // Stringify the object. Attempt to warn/recover on error.
     var str;
     if (noemit || this.haveNonRawStreams) {
-        try {
-            str = JSON.stringify(rec, safeCycles()) + '\n';
-        } catch (e) {
-            if (safeJsonStringify) {
-                str = safeJsonStringify(rec) + '\n';
-            } else {
-                var dedupKey = e.stack.split(/\n/g, 2).join('\n');
-                _warn('bunyan: ERROR: Exception in '
-                    + '`JSON.stringify(rec)`. You can install the '
-                    + '"safe-json-stringify" module to have Bunyan fallback '
-                    + 'to safer stringification. Record:\n'
-                    + _indent(format('%s\n%s', util.inspect(rec), e.stack)),
-                    dedupKey);
-                str = format('(Exception in JSON.stringify(rec): %j. '
-                    + 'See stderr for details.)\n', e.message);
+        if (this.customStringify) {
+            str = this.customStringify(rec);
+        } else {
+            try {
+                str = JSON.stringify(rec, safeCycles()) + '\n';
+            } catch (e) {
+                if (safeJsonStringify) {
+                    str = safeJsonStringify(rec) + '\n';
+                } else {
+                    var dedupKey = e.stack.split(/\n/g, 2).join('\n');
+                    _warn('bunyan: ERROR: Exception in '
+                        + '`JSON.stringify(rec)`. You can install the '
+                        + '"safe-json-stringify" module to have Bunyan fallback '
+                        + 'to safer stringification. Record:\n'
+                        + _indent(format('%s\n%s', util.inspect(rec), e.stack)),
+                        dedupKey);
+                    str = format('(Exception in JSON.stringify(rec): %j. '
+                        + 'See stderr for details.)\n', e.message);
+                }
             }
         }
     }

--- a/test/custom-stringifier.test.js
+++ b/test/custom-stringifier.test.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 Trent Mick.
+ *
+ * Test `customStringifier` usage.
+ */
+
+function logSomething(log) { log.info('something'); }
+
+var Logger = require('../lib/bunyan');
+
+// node-tap API
+if (require.cache[__dirname + '/tap4nodeunit.js'])
+        delete require.cache[__dirname + '/tap4nodeunit.js'];
+var tap4nodeunit = require('./tap4nodeunit.js');
+var after = tap4nodeunit.after;
+var before = tap4nodeunit.before;
+var test = tap4nodeunit.test;
+
+
+function CapturingStream(recs) {
+    this.recs = recs;
+}
+
+CapturingStream.prototype.write = function (rec) {
+    this.recs.push(rec);
+};
+
+
+test('customStringifier', function (t) {
+    var recs = [];
+
+    var log = new Logger({
+        name: 'custom-stringifier-test',
+        customStringify: function(rec) {
+            console.log("Hello");
+            return rec.msg;
+        },
+        streams: [
+            {
+                stream: new CapturingStream(recs)
+            }
+        ]
+    });
+
+    log.info('top-level');
+    logSomething(log);
+
+    t.equal(recs.length, 2);
+    recs.forEach(function (rec) {
+        console.log(rec);
+        t.equal(typeof rec, 'string');
+    });
+
+    t.equal(recs[0], "top-level");
+    t.equal(recs[1], "something");
+
+    t.end();
+});


### PR DESCRIPTION
Hi Trent, 

would you accept my change? the project that I'm working on requires simple key=value output, and also file rotation (and we are pretty much tied to using restify with bunyan, and the features it supports).

I tried using a raw stream together with the package bunyan-rotating-filestream, but it has bugs. 

Thanks
Mario