### PR TITLE
FATAL BUG: rotate() OR _setupNextRot() on start

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1244,8 +1244,9 @@ RotatingFileStream = function RotatingFileStream(options) {
     this.rotating = false;
     if (rotateAfterOpen) {
         this.rotate();
+    } else {
+        this._setupNextRot();
     }
-    this._setupNextRot();
 }
 
 util.inherits(RotatingFileStream, EventEmitter);


### PR DESCRIPTION
An exception will be thrown, "cannot start a rotation when already rotating" due to a race condition caused by `rotate()` and `_setupNextRot()` called at the same time, if `_setRotationTimer()` is called inside `rotate()`.