### PR TITLE
Add shorthand log level function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ log.info(err, 'more on this: %s', more);
 log.info({foo: 'bar', err: err}, 'some msg about this error');
                 // To pass in an Error *and* other fields, use the `err`
                 // field name for the Error instance.
+
+log.i('this is the shorthand way to use log.info');
 ```
 
 Note that this implies **you cannot blindly pass any object as the first

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1063,12 +1063,12 @@ function mkLogEmitter(minLevel) {
  *    arguments that are handled like
  *    [util.format](http://nodejs.org/docs/latest/api/all.html#util.format).
  */
-Logger.prototype.trace = mkLogEmitter(TRACE);
-Logger.prototype.debug = mkLogEmitter(DEBUG);
-Logger.prototype.info = mkLogEmitter(INFO);
-Logger.prototype.warn = mkLogEmitter(WARN);
-Logger.prototype.error = mkLogEmitter(ERROR);
-Logger.prototype.fatal = mkLogEmitter(FATAL);
+Logger.prototype.trace = Logger.prototype.t = mkLogEmitter(TRACE);
+Logger.prototype.debug = Logger.prototype.d = mkLogEmitter(DEBUG);
+Logger.prototype.info = Logger.prototype.i = mkLogEmitter(INFO);
+Logger.prototype.warn = Logger.prototype.w = mkLogEmitter(WARN);
+Logger.prototype.error = Logger.prototype.e = mkLogEmitter(ERROR);
+Logger.prototype.fatal = Logger.prototype.f = mkLogEmitter(FATAL);
 
 
 

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -64,6 +64,23 @@ test('log.LEVEL() -> boolean', function (t) {
     t.end();
 });
 
+test('log.LEVEL -> shorthand notation', function (t) {
+    t.equal(log1.trace, log1.t)
+    t.equal(log1.debug, log1.d)
+    t.equal(log1.info, log1.i)
+    t.equal(log1.warn, log1.w)
+    t.equal(log1.error, log1.e)
+    t.equal(log1.fatal, log1.f)
+
+    t.equal(log2.trace, log2.t)
+    t.equal(log2.debug, log2.d)
+    t.equal(log2.info, log2.i)
+    t.equal(log2.warn, log2.w)
+    t.equal(log2.error, log2.e)
+    t.equal(log2.fatal, log2.f)
+    t.end();
+});
+
 
 // ---- test `log.<level>(...)` calls which various input types
 


### PR DESCRIPTION
Minor change for convenience. Allows the use of shorthand function names:

```js
log.i('info')
log.w('warn')
```