### PR TITLE
docs(): usage with gulp/nodemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,42 @@ $ node hi.js | bunyan -c 'this.lang == "fr"'
 
 See `bunyan --help` for other facilities.
 
+## Use with Gulp and Nodemon
+
+If you use [gulp-nodemon](https://www.npmjs.com/package/gulp-nodemon) to run your
+application during development, you can automatically pipe the application's output
+through the bunyan CLI to format it:
+
+```js
+var nodemon = require('gulp-nodemon');
+var childProcess = require('child_process');
+var path = require('path');
+
+gulp.task('server', function (done) {
+
+	nodemon({
+		script: './server.js', // <-- your application
+		watch: ['./app'],
+		stdout: false // <-- important, otherwise output won't get piped properly
+	})
+	.on('readable', function () {
+		// Pass output through bunyan formatter
+		var bunyan = childProcess.fork(
+			path.join('.', 'node_modules', 'bunyan', 'bin', 'bunyan'),
+			['--output', 'simple'], // <-- any of the CLI options that you prefer
+			{silent: true}
+		);
+
+		bunyan.stdout.pipe(process.stdout);
+		bunyan.stderr.pipe(process.stderr);
+		this.stdout.pipe(bunyan.stdin);
+		this.stderr.pipe(bunyan.stdin);
+	});
+
+	done();
+};
+
+```
 
 ## Streams Introduction
 


### PR DESCRIPTION
Document how to do this... comes up in a number of google searches.

Relates to https://github.com/JacksonGariety/gulp-nodemon/issues/103. (While that suggests that this should be an improvement made to gulp-nodemon, I still think it's valuable to document this here.)