### PR TITLE
Added Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+
+os:
+  - linux
+  - osx
+
+node_js:
+  - '0.10'
+  - '0.12'
+  - '4'
+  - '5'
+  - 'node'
+  - 'iojs'
+
+# Gives us faster boot time, see https://docs.travis-ci.com/user/ci-environment/
+sudo: false
+
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,16 @@ os:
   - linux
   - osx
 
+env:
+ - SKIP_DTRACE=1
+
 node_js:
   - '0.10'
   - '0.12'
   - '4'
   - '5'
+  - '6'
   - 'node'
-  - 'iojs'
 
 # Gives us faster boot time, see https://docs.travis-ci.com/user/ci-environment/
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![npm version](https://img.shields.io/npm/v/bunyan.svg?style=flat)](https://www.npmjs.com/package/bunyan)
+[![Build Status](https://travis-ci.org/trentm/node-bunyan.svg?branch=master)](https://travis-ci.org/trentm/node-bunyan)
 
 Bunyan is **a simple and fast JSON logging library** for node.js services:
 


### PR DESCRIPTION
Fixes #342
- [ ] Enable builds at https://travis-ci.org/trentm/node-bunyan

For sample builds, see https://travis-ci.org/Srokap/node-bunyan/builds 

There seems to be some random failures on osx that go away on reruns, they look like that:

```
> make test
test -z "1" || test -n "" || \
        (node -e 'require("dtrace-provider").createDTraceProvider("isthisthingon")' && \
        echo "\nNote: Use 'SKIP_DTRACE=1 make test' to skip parts of the test suite that require root." && \
        sudo ./node_modules/.bin/nodeunit test/dtrace.test.js)
Note: Use 'SKIP_DTRACE=1 make test' to skip parts of the test suite that require root.
dtrace.test.js
✔ basic dtrace
✖ bunyan -p
AssertionError: 20 == 10
    at Object.equal (/Users/travis/build/Srokap/node-bunyan/node_modules/nodeunit/lib/types.js:83:39)
    at ChildProcess.<anonymous> (/Users/travis/build/Srokap/node-bunyan/test/dtrace.test.js:108:15)
    at ChildProcess.emit (events.js:110:17)
    at Process.ChildProcess._handle.onexit (child_process.js:1078:12)
AssertionError: 'hi at debug' == 'hi at trace'
    at Object.equal (/Users/travis/build/Srokap/node-bunyan/node_modules/nodeunit/lib/types.js:83:39)
    at ChildProcess.<anonymous> (/Users/travis/build/Srokap/node-bunyan/test/dtrace.test.js:109:15)
    at ChildProcess.emit (events.js:110:17)
    at Process.ChildProcess._handle.onexit (child_process.js:1078:12)
FAILURES: 2/11 assertions failed (4468ms)
make: *** [test] Error 1
npm ERR! Test failed.  See above for more details.
The command "npm test" exited with 1.
Done. Your build exited with 1.
```
