### PR TITLE
Patch: On reopenFileStream reopen children's streams as well

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -355,6 +355,8 @@ function Logger(options, _childOptions, _childSimple) {
         return new Logger(options, _childOptions);
     }
 
+    this.childs= [];
+
     // Input arg validation.
     var parent;
     if (_childOptions !== undefined) {
@@ -388,6 +390,8 @@ function Logger(options, _childOptions, _childSimple) {
             Array.isArray(options.serializers))) {
         throw new TypeError('invalid options.serializers: must be an object')
     }
+
+    if ( parent ) parent.childs.push(this);
 
     EventEmitter.call(this);
 
@@ -723,6 +727,10 @@ Logger.prototype.reopenFileStreams = function () {
                 self.emit('error', err, s);
             });
         }
+    });
+    // reopen childs' streams as well
+    self.childs.forEach(function( child ) {
+        child.reopenFileStreams();
     });
 };
 


### PR DESCRIPTION
We had a problem in restify's audit logger. It creates a child of the given logger and there was no way to reopen all file streams for log rotation.
So we register forked instances at the parent to reopen their streams as well.