### PR TITLE
Support filtering of log messages (#443)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,11 @@ Known issues:
   bug](https://github.com/TooTallNate/node-gyp/issues/65).
 
 
-## 1.8.2 (not yet released)
+## 1.9.0 (not yet released)
 
 - [issue #426] Ensure `log.info({err: err})` results in a "msg" value, just
   like `log.info(err)`.
+- [issue #443] Support filtering of log messages. (by Ben Ripkens.)
 
 
 ## 1.8.1

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Also: log4j is way more than you need.
   * [stream type: `raw`](#stream-type-raw)
   * [`raw` + RingBuffer Stream](#raw--ringbuffer-stream)
   * [third-party streams](#third-party-streams)
+- [Filtering of log messages](#filtering-of-log-messages)
 - [Runtime log snooping via DTrace](#runtime-log-snooping-via-dtrace)
   * [DTrace examples](#dtrace-examples)
 - [Runtime environments](#runtime-environments)
@@ -1061,6 +1062,39 @@ place to start.)
 - TODO: eventually https://github.com/trentm/node-bunyan-winston
 
 
+# Filtering of log messages
+Log messages can be filtered before they are formatted and written to
+streams. This filtering capability can be used to throttle log
+messages, to remove duplicate messages or to filter log messages with
+sensitive information. At its core, a filter is a function of the
+following form:
+
+```js
+function myFilter (level, msgArgs) {
+    return /Error/i.test(msgArgs[0]);
+}
+```
+
+Clarifying, the filter will receive the log level as a `Number` and
+the arguments used when calling the logging functions, i.e.
+`log.info(…)`, `log.warn(…)`, as an `Arguments` object. Note that
+there are no guarantees about the contents of the `Arguments` objects
+as the content depends on the caller of the logging functions. When
+filter functions return falsy values, the log messages will be ignored.
+
+Filters can be registered via the `log.addFilter(myFilter)` function or
+via the logger options. Example:
+
+```js
+bunyan.createLogger({
+    name: 'log1',
+    filters: [
+        function myFilter (level, msgArgs) {
+            return /Error/i.test(msgArgs[0]);
+        }
+    ]
+});
+```
 
 # Runtime log snooping via DTrace
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -401,6 +401,7 @@ function Logger(options, _childOptions, _childSimple) {
         this.streams = parent.streams;
         this.serializers = parent.serializers;
         this.src = parent.src;
+        this.filters = parent.filters;
         var fields = this.fields = {};
         var parentFieldNames = Object.keys(parent.fields);
         for (var i = 0; i < parentFieldNames.length; i++) {
@@ -428,6 +429,7 @@ function Logger(options, _childOptions, _childSimple) {
         this.serializers = objCopy(parent.serializers);
         this.src = parent.src;
         this.fields = objCopy(parent.fields);
+        this.filters = objCopy(parent.filters);
         if (options.level) {
             this.level(options.level);
         }
@@ -437,6 +439,7 @@ function Logger(options, _childOptions, _childSimple) {
         this.serializers = null;
         this.src = false;
         this.fields = {};
+        this.filters = [];
     }
 
     if (!dtp && dtrace) {
@@ -497,6 +500,11 @@ function Logger(options, _childOptions, _childSimple) {
     if (options.serializers) {
         self.addSerializers(options.serializers);
     }
+    if (options.filters) {
+        options.filters.forEach(function (filter) {
+            self.addFilter(filter);
+        });
+    }
     if (options.src) {
         this.src = true;
     }
@@ -513,6 +521,7 @@ function Logger(options, _childOptions, _childSimple) {
     delete fields.streams;
     delete fields.serializers;
     delete fields.src;
+    delete fields.filters;
     if (this.serializers) {
         this._applySerializers(fields);
     }
@@ -1038,6 +1047,8 @@ function mkLogEmitter(minLevel) {
             return (this._level <= minLevel);
         } else if (this._level > minLevel) {
             /* pass through */
+        } else if (!this._satisfiesFilters(minLevel, msgArgs)) {
+          return;
         } else {
             rec = mkRecord(msgArgs);
             str = this._emit(rec);
@@ -1076,6 +1087,36 @@ Logger.prototype.warn = mkLogEmitter(WARN);
 Logger.prototype.error = mkLogEmitter(ERROR);
 Logger.prototype.fatal = mkLogEmitter(FATAL);
 
+
+/**
+ * Add a filter
+ *
+ * @param filterFn {Function}. Function which accepts the following parameters:
+ *    - `level`: The level of the log message as a number.
+ *    - `msgArgs`: An arguments object representing the arguments used when
+ *       calling log.<level>(…). Note that no message formatting has happened
+ *       at this point. Content of the array depends solely on the way the
+ *       log functions are used.
+ *    The function should return a falsy value to indicate that the log message
+ *    should be ignored.
+ *    See README.md for full details.
+ */
+Logger.prototype.addFilter = function addFilter(filterFn) {
+    this.filters.push(filterFn);
+}
+
+
+// Verfifies whether the given level and message arguments satisfy
+// all the loggers filters.
+Logger.prototype._satisfiesFilters = function (level, msgArgs) {
+    for (var i = 0, len = this.filters.length; i < len; i++) {
+        if (!this.filters[i](level, msgArgs)) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 
 //---- Standard serializers

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "nodeunit": "0.9",
     "ben": "0.0.0",
     "markdown-toc": "0.12.x",
+    "sinon": "1.17.6",
     "verror": "1.3.3",
     "vasync": "1.4.3"
   },

--- a/test/Catcher.js
+++ b/test/Catcher.js
@@ -1,0 +1,11 @@
+var Catcher = module.exports = exports = function Catcher() {
+    this.records = [];
+}
+
+Catcher.prototype.write = function (record) {
+    this.records.push(record);
+}
+
+Catcher.prototype.clear = function () {
+    this.records = [];
+}

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016 Trent Mick. All rights reserved.
+ *
+ * Test that log filters are applied
+ */
+
+var sinon = require('sinon');
+var util = require('util'),
+    format = util.format,
+    inspect = util.inspect;
+var p = console.log;
+
+var bunyan = require('../lib/bunyan');
+var Catcher = require('./Catcher');
+
+// node-tap API
+if (require.cache[__dirname + '/tap4nodeunit.js'])
+        delete require.cache[__dirname + '/tap4nodeunit.js'];
+var tap4nodeunit = require('./tap4nodeunit.js');
+var after = tap4nodeunit.after;
+var before = tap4nodeunit.before;
+var test = tap4nodeunit.test;
+
+
+var log;
+var catcher;
+
+before(function (cb) {
+    catcher = new Catcher();
+    log = bunyan.createLogger({
+        name: 'log1',
+        streams: [
+            {
+                type: 'raw',
+                stream: catcher,
+                level: 'info'
+            }
+        ]
+    });
+
+    cb();
+})
+
+
+test('log level filtering must be done first', function (t) {
+    var filter = sinon.stub().returns(true);
+    log.addFilter(filter);
+    log.debug('debug...');
+    t.equal(catcher.records.length, 0);
+    t.equal(filter.callCount, 0);
+    t.end();
+});
+
+
+test('filters must be applied with called arguments', function (t) {
+    var filter = function (level, msgArgs) {
+        return msgArgs[0] === 'a';
+    };
+    log.addFilter(filter);
+    log.info('a');
+    log.info('b');
+    log.info('a');
+
+    t.equal(catcher.records.length, 2);
+    t.equal(catcher.records[0].msg, 'a');
+    t.equal(catcher.records[1].msg, 'a');
+    t.end();
+});
+
+
+test('filters must be inherited from parent loggers', function (t) {
+    var parentFilter = function (level, msgArgs) {
+        return msgArgs[1] === 'a';
+    };
+    log.addFilter(parentFilter);
+
+    var childLog = log.child({
+        filters: [
+            function (level, msgArgs) {
+                return msgArgs[2] === 'b';
+            }
+        ]
+    });
+
+    childLog.info('1: %s %s', 'a', 'c');
+    childLog.info('2: %s %s', 'a', 'b');
+    childLog.info('3: %s %s', 'b', 'a');
+    childLog.info('4: %s %s', 'c', 'b');
+
+    t.equal(catcher.records.length, 1);
+    t.equal(catcher.records[0].msg, '2: a b');
+    t.end();
+});

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -10,6 +10,7 @@ var util = require('util'),
 var p = console.log;
 
 var bunyan = require('../lib/bunyan');
+var Catcher = require('./Catcher');
 
 // node-tap API
 if (require.cache[__dirname + '/tap4nodeunit.js'])
@@ -67,12 +68,6 @@ test('log.LEVEL() -> boolean', function (t) {
 
 // ---- test `log.<level>(...)` calls which various input types
 
-function Catcher() {
-    this.records = [];
-}
-Catcher.prototype.write = function (record) {
-    this.records.push(record);
-}
 var catcher = new Catcher();
 var log3 = new bunyan.createLogger({
     name: 'log3',


### PR DESCRIPTION
Adds basic facilities required for #443.

Once merged, duplicate log message filters can be build. Better to remove this from core since there are bound to be different interpretations of what a duplicate message is.
