### PR TITLE
Alternative implementation of `Caller3Info`

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -175,34 +175,28 @@ if (!format) {
 
 /**
  * Gather some caller info 3 stack levels up.
- * See <http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi>.
+ * See <https://github.com/v8/v8/wiki/Stack-Trace-API>.
  */
-function getCaller3Info() {
-    if (this === undefined) {
-        // Cannot access caller info in 'strict' mode.
-        return;
-    }
-    var obj = {};
+function Caller3Info() {
     var saveLimit = Error.stackTraceLimit;
     var savePrepare = Error.prepareStackTrace;
     Error.stackTraceLimit = 3;
-    Error.captureStackTrace(this, getCaller3Info);
+    Error.captureStackTrace(this, Caller3Info);
 
-    Error.prepareStackTrace = function (_, stack) {
+    Error.prepareStackTrace = function (error, stack) {
         var caller = stack[2];
         if (sourceMapSupport) {
             caller = sourceMapSupport.wrapCallSite(caller);
         }
-        obj.file = caller.getFileName();
-        obj.line = caller.getLineNumber();
+        error.file = caller.getFileName();
+        error.line = caller.getLineNumber();
         var func = caller.getFunctionName();
         if (func)
-            obj.func = func;
+            error.func = func;
     };
     this.stack;
     Error.stackTraceLimit = saveLimit;
     Error.prepareStackTrace = savePrepare;
-    return obj;
 }
 
 
@@ -1007,7 +1001,7 @@ function mkLogEmitter(minLevel) {
             }
             // Get call source info
             if (log.src && !rec.src) {
-                rec.src = getCaller3Info()
+                rec.src = new Caller3Info()
             }
             rec.v = LOG_VERSION;
 
@@ -1027,7 +1021,7 @@ function mkLogEmitter(minLevel) {
              */
             var dedupKey = 'unbound';
             if (!_haveWarned[dedupKey]) {
-                var caller = getCaller3Info();
+                var caller = new Caller3Info();
                 _warn(format('bunyan usage error: %s:%s: attempt to log '
                     + 'with an unbound log method: `this` is: %s',
                     caller.file, caller.line, util.inspect(this)),


### PR DESCRIPTION
With the current implementation of [`getCaller3Info`](https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L180) were getting the following error under hard to reproduce circumstances (usually it only happens after running some sequence of our integration test suite, and it seems to only have started happening after we introduced [bwip-js](https://github.com/metafloor/bwip-js) which uses [Emscripten](http://kripken.github.io/emscripten-site/) as a dependency of our project: 
```
/home/pmcnr/work/hapi/node_modules/bunyan/lib/bunyan.js:189
    Error.captureStackTrace(this, getCaller3Info);
          ^

TypeError: Cannot define property:stack, object is not extensible.
    at defineProperty (native)
    at getCaller3Info (/home/pmcnr/work/hapi/node_modules/bunyan/lib/bunyan.js:189:11)
    at mkRecord (/home/pmcnr/work/hapi/node_modules/bunyan/lib/bunyan.js:1004:27)
```

The alternative implementation proposed in this PR seems to implement the same function of `getCaller3Info` while fixing the above issue.