### PR TITLE
Bump version of dtrace-provider to support Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "// mv": "required for RotatingFileStream",
   "// moment": "required for local time with CLI",
   "optionalDependencies": {
-    "dtrace-provider": "~0.6",
+    "dtrace-provider": "~0.7",
     "mv": "~2",
     "safe-json-stringify": "~1",
     "moment": "^2.10.6"


### PR DESCRIPTION
This aims to solve the same issue as #417, but now that dtrace-provider has fixed the issue, it should be better to just bump its version