### PR TITLE
filesize logrotate and log only specified level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,7 +892,8 @@ var log = bunyan.createLogger({
         type: 'rotating-file',
         path: '/var/log/foo.log',
         period: '1d',   // daily rotation
-        count: 3        // keep 3 back copies
+        count: 3,        // keep 3 back copies,
+        maxSizeKB: 1024 // rotate every 1024KB
     }]
 });
 ```

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1447,7 +1447,7 @@ RotatingFileStream.prototype.rotate = function rotate() {
         var before = self.path;
         var after = self.path + '.' + String(n);
         if (n > 0) {
-            before += '.' + String(n - 1) + '.tar.gz';
+            before += '.' + String(n - 1);
         }
         n -= 1;
         fs.exists(before, function (exists) {

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -333,6 +333,8 @@ function isWritable(obj) {
  *        See README.md for full details.
  *      - `level`: set the level for a single output stream (cannot be used
  *        with `streams`)
+ *      - `logOnlySetLevel`: Use level as the only level to log and not a
+ *        threshold (Defaut: false)
  *      - `stream`: the output stream for a logger with just one, e.g.
  *        `process.stdout` (cannot be used with `streams`)
  *      - `serializers`: object mapping log record field names to
@@ -398,6 +400,7 @@ function Logger(options, _childOptions, _childSimple) {
         this._isSimpleChild = true;
 
         this._level = parent._level;
+        this._logOnlyMinLevel = parent._logOnlyMinLevel;
         this.streams = parent.streams;
         this.serializers = parent.serializers;
         this.src = parent.src;
@@ -419,6 +422,7 @@ function Logger(options, _childOptions, _childSimple) {
     var self = this;
     if (parent) {
         this._level = parent._level;
+        this._logOnlyMinLevel = parent._logOnlyMinLevel;
         this.streams = [];
         for (var i = 0; i < parent.streams.length; i++) {
             var s = objCopy(parent.streams[i]);
@@ -433,6 +437,7 @@ function Logger(options, _childOptions, _childSimple) {
         }
     } else {
         this._level = Number.POSITIVE_INFINITY;
+        this._logOnlyMinLevel = false;
         this.streams = [];
         this.serializers = null;
         this.src = false;
@@ -605,6 +610,7 @@ Logger.prototype.addStream = function addStream(s, defaultLevel) {
         assert.ok(s.path);
         assert.ok(mv, '"rotating-file" stream type is not supported: '
                       + 'missing "mv" module');
+
         s.stream = new RotatingFileStream(s);
         if (!s.closeOnExit) {
             s.closeOnExit = true;
@@ -1038,7 +1044,7 @@ function mkLogEmitter(minLevel) {
             return (this._level <= minLevel);
         } else if (this._level > minLevel) {
             /* pass through */
-        } else {
+        } else if ((this._level === minLevel && this._logOnlyMinLevel) || (this._level <= minLevel && !this._logOnlyMinLevel)) {
             rec = mkRecord(msgArgs);
             str = this._emit(rec);
         }
@@ -1176,9 +1182,16 @@ RotatingFileStream = function RotatingFileStream(options) {
     this.path = options.path;
 
     this.count = (options.count == null ? 10 : options.count);
+    this.maxSizeKB = (options.maxSizeKB == null ? 1024 * 512 /* 512MB */ : options.maxSizeKB);
+
     assert.equal(typeof (this.count), 'number',
         format('rotating-file stream "count" is not a number: %j (%s) in %j',
             this.count, typeof (this.count), this));
+
+    assert.equal(typeof (this.maxSizeKB), 'number',
+        format('rotating-file stream "maxSizeKB" is not a number: %j (%s) in %j',
+            this.maxSizeKB, typeof (this.maxSizeKB), this));
+
     assert.ok(this.count >= 0,
         format('rotating-file stream "count" is not >= 0: %j in %j',
             this.count, this));
@@ -1211,15 +1224,23 @@ RotatingFileStream = function RotatingFileStream(options) {
         this.periodScope = 'd';
     }
 
+    var fileSizeBytes = 0;
     var lastModified = null;
+    var rotateAfterOpen = false;
+
     try {
         var fileInfo = fs.statSync(this.path);
+
+        fileSizeBytes = fileInfo.size;
         lastModified = fileInfo.mtime.getTime();
+    } catch (err) {
+        this._debug(`Log file ${this.path} does not exist`);
     }
-    catch (err) {
-        // file doesn't exist
+
+    if (fileSizeBytes / 1024 > this.maxSizeKB) {
+        rotateAfterOpen = true;
     }
-    var rotateAfterOpen = false;
+
     if (lastModified) {
         var lastRotTime = this._calcRotTime(0);
         if (lastModified < lastRotTime) {
@@ -1426,7 +1447,7 @@ RotatingFileStream.prototype.rotate = function rotate() {
         var before = self.path;
         var after = self.path + '.' + String(n);
         if (n > 0) {
-            before += '.' + String(n - 1);
+            before += '.' + String(n - 1) + '.tar.gz';
         }
         n -= 1;
         fs.exists(before, function (exists) {


### PR DESCRIPTION
This PR adds support for log rotation with file size limitation additionally to the period of time rotation.

Also, add support to log only the specific log level (e.g: log only WARN), this is a global setting that will affect all streams.

Will create a patch in the future to add per stream support if will be required.