### PR TITLE
Add an option to log undefined values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ provide feedback on it and merge it. I'll politely request missing pieces.
 - Any user visible change in behaviour should almost certainly include an
   update to the docs. Currently the "docs" is the README.md.
 
-- Adding a test case for code changes is **stronly recommended**, else I
+- Adding a test case for code changes is **strongly recommended**, else I
   can't easily promise to not break your fix/feature later. If you don't
   grok the test suite, please ask. We can use it to form the basis for a
   "test/README.md".

--- a/examples/specific-level-streams.js
+++ b/examples/specific-level-streams.js
@@ -9,7 +9,7 @@
  */
 
 var bunyan = require('../lib/bunyan'),
-    safeCycles = bunyan.safeCycles;
+    replacer = bunyan.replacer;
 var fs = require('fs');
 
 /**
@@ -28,7 +28,7 @@ function SpecificLevelStream(levels, stream) {
 }
 SpecificLevelStream.prototype.write = function (rec) {
     if (this.levels[rec.level] !== undefined) {
-        var str = JSON.stringify(rec, safeCycles()) + '\n';
+        var str = JSON.stringify(rec, replacer()) + '\n';
         this.stream.write(str);
     }
 }

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -155,7 +155,7 @@ if (!format) {
             switch (x) {
                 case '%s': return String(args[i++]);
                 case '%d': return Number(args[i++]);
-                case '%j': return JSON.stringify(args[i++], safeCycles());
+                case '%j': return JSON.stringify(args[i++], replacer());
                 case '%%': return '%';
                 default:
                     return x;
@@ -340,6 +340,7 @@ function isWritable(obj) {
  *        serializing functions. See README.md for details.
  *      - `src`: Boolean (default false). Set true to enable 'src' automatic
  *        field with log call source info.
+ *      - `logUndefined`: Boolean (default false). Set true to enable logging undefined values as string ('undefined')
  *    All other keys are log record fields.
  *
  * An alternative *internal* call signature is used for creating a child:
@@ -428,6 +429,7 @@ function Logger(options, _childOptions, _childSimple) {
         }
         this.serializers = objCopy(parent.serializers);
         this.src = parent.src;
+        this.logUndefined = parent.logUndefined; // TODO need ?
         this.fields = objCopy(parent.fields);
         if (options.level) {
             this.level(options.level);
@@ -501,6 +503,7 @@ function Logger(options, _childOptions, _childSimple) {
     if (options.src) {
         this.src = true;
     }
+    this.logUndefined = options.logUndefined;
     xxx('Logger: ', self)
 
     // Fields.
@@ -510,6 +513,7 @@ function Logger(options, _childOptions, _childSimple) {
     // any changes.
     var fields = objCopy(options);
     delete fields.stream;
+    delete fields.logUndefined;
     delete fields.level;
     delete fields.streams;
     delete fields.serializers;
@@ -909,7 +913,9 @@ Logger.prototype._emit = function (rec, noemit) {
     var str;
     if (noemit || this.haveNonRawStreams) {
         try {
-            str = JSON.stringify(rec, safeCycles()) + '\n';
+            str = JSON.stringify(rec,
+                                 replacer({logUndefined: this.logUndefined})) + '\n';
+
         } catch (e) {
             if (safeJsonStringify) {
                 str = safeJsonStringify(rec) + '\n';
@@ -1168,12 +1174,15 @@ var errSerializer = Logger.stdSerializers.err = function err(err) {
 };
 
 
-// A JSON stringifier that handles cycles safely.
-// Usage: JSON.stringify(obj, safeCycles())
-function safeCycles() {
+// A JSON stringifier that handles cycles safely and an option of logging string 'undefined' for undefined values
+// Usage: JSON.stringify(obj, replacer())
+function replacer(opts) {
     var seen = [];
     return function (key, val) {
         if (!val || typeof (val) !== 'object') {
+            if (typeof (val) === 'undefined' && opts && opts.logUndefined) {
+              return 'undefined';
+            }
             return val;
         }
         if (seen.indexOf(val) !== -1) {
@@ -1577,5 +1586,5 @@ module.exports.RotatingFileStream = RotatingFileStream;
 
 // Useful for custom `type == 'raw'` streams that may do JSON stringification
 // of log records themselves. Usage:
-//    var str = JSON.stringify(rec, bunyan.safeCycles());
-module.exports.safeCycles = safeCycles;
+//    var str = JSON.stringify(rec, bunyan.replacer());
+module.exports.replacer = replacer;

--- a/test/log-undefined.test.js
+++ b/test/log-undefined.test.js
@@ -1,0 +1,83 @@
+var Logger = require('../lib/bunyan.js');
+
+// node-tap API
+if (require.cache[__dirname + '/tap4nodeunit.js'])
+  delete require.cache[__dirname + '/tap4nodeunit.js'];
+var tap4nodeunit = require('./tap4nodeunit.js');
+var after = tap4nodeunit.after;
+var before = tap4nodeunit.before;
+var test = tap4nodeunit.test;
+
+
+var Stream = require('stream').Stream;
+var outstr = new Stream;
+outstr.writable = true;
+var output = [];
+outstr.write = function (c) {
+  output.push(JSON.parse(c + ''));
+};
+outstr.end = function (c) {
+  if (c) this.write(c);
+  this.emit('end');
+};
+
+// these are lacking a few fields that will probably never match
+var expect =
+  [
+    {
+      'name': 'blammo',
+      'level': 30,
+      'msg': 'bango { bang: \'boom\', somethingUndefined: undefined }',
+      'v': 0
+    },
+    {
+      'name': 'blammo',
+      'level': 30,
+      'bang': 'boom',
+      'somethingUndefined': 'undefined',
+      'msg': '',
+      'v': 0
+    },
+    {
+      'name': 'blammo',
+      'level': 30,
+      'nope': 'undefined',
+      'msg': 'oh no',
+      'v': 0
+    }
+  ];
+
+  var log = new Logger({
+    name: 'blammo',
+    streams: [
+      {
+        type: 'stream',
+        level: 'info',
+        stream: outstr
+      }
+    ],
+    logUndefined: true
+  });
+
+  test('log-undefined', function (t) {
+    outstr.on('end', function () {
+      output.forEach(function (o, i) {
+        // Drop variable parts for comparison.
+        delete o.hostname;
+        delete o.pid;
+        delete o.time;
+        // Hack object/dict comparison: JSONify.
+        t.equal(JSON.stringify(o), JSON.stringify(expect[i]),
+                'log item ' + i + ' matches');
+      });
+      t.end();
+    });
+
+    var obj = { bang: 'boom', somethingUndefined: undefined };
+    var obj2 = {nope: undefined };
+    log.info('bango', obj);
+    log.info(obj);
+    log.info(obj2, 'oh no');
+    outstr.end();
+    t.ok('did not throw');
+  });


### PR DESCRIPTION
If a value is undefined, it does not appear in the output due to how `JSON.stringify`'s `replacer` fn works. In practice I've resorted to doing things like `logger.info({thing: a || 'undefined'})` and would like a functionality like that to be built in (I don't know values are missing unless I track them down). Thus I propose adding this as an option when creating the logger instance. I piggyback on the existing safeCycles fn since it is doing cycle checks anyway. What do you guys think? I would love if this option could get in. All tests pass. Thanks~

@trentm 

