### PR TITLE
#489 handle missing stack trace information

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -189,14 +189,16 @@ function getCaller3Info() {
 
     Error.prepareStackTrace = function (_, stack) {
         var caller = stack[2];
-        if (sourceMapSupport) {
-            caller = sourceMapSupport.wrapCallSite(caller);
+        if(caller){
+            if (sourceMapSupport) {
+                caller = sourceMapSupport.wrapCallSite(caller);
+            }
+            obj.file = caller.getFileName();
+            obj.line = caller.getLineNumber();
+            var func = caller.getFunctionName();
+            if (func)
+                obj.func = func;
         }
-        obj.file = caller.getFileName();
-        obj.line = caller.getLineNumber();
-        var func = caller.getFunctionName();
-        if (func)
-            obj.func = func;
     };
     Error.captureStackTrace(this, getCaller3Info);
     this.stack;


### PR DESCRIPTION
In the context of a promise, some stack trace information is simple not available and this must be handled.