### PR TITLE
Update README.md to use webpack noParse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,26 +1376,18 @@ log.info('hi on info');
 
 ## Webpack
 Webpack can work with the same example Browserify above. To do this, we need to make webpack ignore optional files:
-Create "empty_shim.js":
-```javascript
-// This is an empty shim for things that should be not be included in webpack
+
 ```
-Now tell webpack to use this file for
-[optional dependencies](https://webpack.github.io/docs/configuration.html#resolve-alias)
+Now tell webpack to ignore files for 
+[optional dependencies](https://webpack.js.org/configuration/module/#module-noparse)
 in your "webpack.config.js":
 ```
-resolve: {
-    // These shims are needed for bunyan
-    alias: {
-        'dtrace-provider': '/path/to/shim/empty_shim.js',
-        fs: '/path/to/shim/empty_shim.js',
-        'safe-json-stringify': '/path/to/shim/empty_shim.js',
-        mv: '/path/to/shim/empty_shim.js',
-        'source-map-support': '/path/to/shim/empty_shim.js'
-    }
+module: {
+    noParse: [/dtrace-provider$/, /safe-json-stringify$/, /mv/],
+    ...
 }
 ```
-Now webpack builds, ignoring these optional dependencies via shimming in an empty JS file!
+Now webpack builds.
 
 # Versioning
 


### PR DESCRIPTION
Now with webpack 2 there's no need to write a shim for the modules. Just tell webpack to not parse them.