### PR TITLE
Add 'n' depth stack for src attribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ provide feedback on it and merge it. I'll politely request missing pieces.
 - Any user visible change in behaviour should almost certainly include an
   update to the docs. Currently the "docs" is the README.md.
 
-- Adding a test case for code changes is **stronly recommended**, else I
+- Adding a test case for code changes is **strongly recommended**, else I
   can't easily promise to not break your fix/feature later. If you don't
   grok the test suite, please ask. We can use it to form the basis for a
   "test/README.md".

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ var log = bunyan.createLogger({
     stream: <node.js stream>,           // Optional, see "Streams" section
     streams: [<bunyan streams>, ...],   // Optional, see "Streams" section
     serializers: <serializers mapping>, // Optional, see "Serializers" section
-    src: <boolean>,                     // Optional, see "src" section
+    src: <boolean | integer>,                     // Optional, see "src" section
 
     // Any other fields are added to all log records as is.
     foo: 'bar',
@@ -499,7 +499,13 @@ including the body).
 ## src
 
 The **source file, line and function of the log call site** can be added to
-log records by using the `src: true` config option:
+log records by using the `src` config option. This option can be integer or boolean. (Default `false`)
+
+An integer is how many stack levels to ignore before grabbing the source file, line and function call name.
+
+A `true` boolean will set the value to `2`.
+
+A higher integer can be used if the logger is behind a custom wrapper.
 
 ```js
 var log = bunyan.createLogger({src: true, ...});

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -177,7 +177,7 @@ if (!format) {
  * Gather some caller info 3 stack levels up.
  * See <http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi>.
  */
-function getCaller3Info() {
+function getCaller3Info(stackHeight) {
     if (this === undefined) {
         // Cannot access caller info in 'strict' mode.
         return;
@@ -185,13 +185,15 @@ function getCaller3Info() {
     var obj = {};
     var saveLimit = Error.stackTraceLimit;
     var savePrepare = Error.prepareStackTrace;
-    Error.stackTraceLimit = 3;
+    Error.stackTraceLimit = stackHeight + 1;
 
     Error.prepareStackTrace = function (_, stack) {
-        var caller = stack[2];
+        var caller = stack[stackHeight];
         if (sourceMapSupport) {
             caller = sourceMapSupport.wrapCallSite(caller);
         }
+        if (!caller)
+            return; // Stack is above the top node call.
         obj.file = caller.getFileName();
         obj.line = caller.getLineNumber();
         var func = caller.getFunctionName();
@@ -499,7 +501,7 @@ function Logger(options, _childOptions, _childSimple) {
         self.addSerializers(options.serializers);
     }
     if (options.src) {
-        this.src = true;
+        this.src = (options.src === true) ? 2 : options.src;
     }
     xxx('Logger: ', self)
 
@@ -987,7 +989,7 @@ function mkRecord(log, minLevel, args) {
     }
     // Get call source info
     if (log.src && !rec.src) {
-        rec.src = getCaller3Info()
+        rec.src = getCaller3Info(log.src)
     }
     rec.v = LOG_VERSION;
 

--- a/test/src.test.js
+++ b/test/src.test.js
@@ -7,6 +7,13 @@
 // Intentionally on line 8 for tests below:
 function logSomething(log) { log.info('something'); }
 
+function someFunc(log) {
+    log.customLevel = function () {
+        log.info('something else');
+    }
+    // Intentionally on line 15 for tests below:
+    log.customLevel();
+}
 
 var format = require('util').format;
 var Logger = require('../lib/bunyan');
@@ -42,10 +49,14 @@ test('src', function (t) {
         ]
     });
 
+    t.equal(log.src, 2);
+
     log.info('top-level');
     logSomething(log);
+    log.src = 3;
+    someFunc(log);
 
-    t.equal(recs.length, 2);
+    t.equal(recs.length, 3);
     recs.forEach(function (rec) {
         t.ok(rec.src);
         t.equal(typeof (rec.src), 'object');
@@ -57,6 +68,10 @@ test('src', function (t) {
     t.ok(rec.src.func);
     t.equal(rec.src.func, 'logSomething');
     t.equal(rec.src.line, 8);
+    var rec = recs[2];
+    t.ok(rec.src.func);
+    t.equal(rec.src.func, 'someFunc');
+    t.equal(rec.src.line, 15);
 
     t.end();
 });


### PR DESCRIPTION
This PR adds the ability to change the `src` depth via an integer value instead of a boolean
Related to #72 

This allows users to wrap their logger in functions and still maintain the correct `src` path/filename/function call when viewing logs.

- Updated readme
- Updated tests
- Fixes small typo in contributing.md


Let me know if theres anything I missed


Also I couldn't get the `make check` to function correctly. It kept complaining about `/bin/sh` not having `[[` 
but it still passed the linter

