### PR TITLE
Implement functional logger attributes

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -969,6 +969,18 @@ function mkRecord(log, minLevel, args) {
 
     // Build up the record object.
     var rec = objCopy(log.fields);
+
+    Object.keys(rec).forEach(function (k) {
+      // Evaulate functions in logger's fields
+      if (typeof rec[k] === 'function') {
+        try {
+          rec[k] = rec[k]();
+        } catch (_) {
+          // Ignore exceptions
+        }
+      }
+    });
+
     var level = rec.level = minLevel;
     var recFields = (fields ? objCopy(fields) : null);
     if (recFields) {

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -85,6 +85,20 @@ var log3 = new bunyan.createLogger({
     ]
 });
 
+var log4Catcher = new Catcher();
+var functionAttribute = 123;
+var log4 = new bunyan.createLogger({
+  name: 'log4',
+  streams: [
+    {
+      type: 'raw',
+      stream: log4Catcher,
+      level: 'trace'
+    }
+  ],
+  funcAttr: function () { return functionAttribute; }
+});
+
 var names = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 var fields = {one: 'un'};
 
@@ -266,6 +280,19 @@ test('log.info(null, <msg>)', function (t) {
         var rec = catcher.records[catcher.records.length - 1];
         t.equal(rec.msg, 'my message',
             format('log.%s msg: got %j', lvl, rec.msg));
+    });
+    t.end();
+});
+
+test('function attributes', function (t) {
+    names.forEach(function (lvl) {
+        functionAttribute = lvl;
+
+        log4[lvl].call(log4, 'some message');
+        var rec = log4Catcher.records[log4Catcher.records.length - 1];
+
+        t.equal(rec.funcAttr, lvl,
+          format('log.%s funcAttr is %s', lvl, rec.funcAttr));
     });
     t.end();
 });


### PR DESCRIPTION
I've implemented a simple feature to allow defining functional attributes when creating loggers. This allows things like global flags/state to be included in logs automatically without explicitly having to pass them into each log message. I've also added a tests.