### PR TITLE
Child logger inherits 'pid' field.

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -518,7 +518,7 @@ function Logger(options, _childOptions, _childSimple) {
     if (!fields.hostname && !self.fields.hostname) {
         fields.hostname = os.hostname();
     }
-    if (!fields.pid) {
+    if (!fields.pid && !self.fields.pid) {
         fields.pid = process.pid;
     }
     Object.keys(fields).forEach(function (k) {

--- a/test/child-behaviour.test.js
+++ b/test/child-behaviour.test.js
@@ -159,3 +159,24 @@ test('child should not lose parent "hostname"', function (t) {
 
     t.end();
 });
+
+// issue #538
+test('child should not lose parent "pid"', function (t) {
+    var stream = new CapturingStream();
+    var parentLogger = bunyan.createLogger({
+        name: 'pid-test',
+        pid: 'my-pid',
+        streams: [ {
+            type: 'raw',
+            stream: stream,
+            level: 'info'
+        } ]
+    });
+    var childLogger = parentLogger.child({foo: 'bar'});
+
+    childLogger.info('hi');
+
+    t.equal(stream.recs[0].pid, 'my-pid');
+
+    t.end();
+});


### PR DESCRIPTION
When a custom pid is configured on a logger, child loggers should inherit its value. Previously child loggers would get the default value from node's `process.pid`.

Fixes https://github.com/trentm/node-bunyan/issues/538.

cc @bobzoller