### PR TITLE
set rec.level after copying user fields

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -969,7 +969,6 @@ function mkRecord(log, minLevel, args) {
 
     // Build up the record object.
     var rec = objCopy(log.fields);
-    var level = rec.level = minLevel;
     var recFields = (fields ? objCopy(fields) : null);
     if (recFields) {
         if (log.serializers) {
@@ -979,6 +978,7 @@ function mkRecord(log, minLevel, args) {
             rec[k] = recFields[k];
         });
     }
+    var level = rec.level = minLevel;
     rec.msg = format.apply(log, msgArgs);
     if (!rec.time) {
         rec.time = (new Date());


### PR DESCRIPTION
since `level` is a core field that cannot be overriden, it should be set after copying user fields.