### PR TITLE
Log custom properties on Error objects

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -934,13 +934,19 @@ function mkRecord(log, minLevel, args) {
     var excludeFields, fields, msgArgs;
     if (args[0] instanceof Error) {
         // `log.<level>(err, ...)`
+        var err = args[0];
         fields = {
             // Use this Logger's err serializer, if defined.
             err: (log.serializers && log.serializers.err
-                ? log.serializers.err(args[0])
-                : Logger.stdSerializers.err(args[0]))
+                ? log.serializers.err(err)
+                : Logger.stdSerializers.err(err))
         };
-        excludeFields = {err: true};
+        for (const key in err) {
+            if (Object.prototype.hasOwnProperty.call(err, key)) {
+                fields[key] = err[key];
+            }
+        }
+        excludeFields = { err: true };
         if (args.length === 1) {
             msgArgs = [fields.err.message];
         } else {


### PR DESCRIPTION
This PR adds support for logging custom properties on error objects. In the current behavior, custom properties are stripped.

**Example:**

```js
const e = new Error('Some exception');
e.customMetadata = { what: 'ever' };
logger.error(e);
```

**Log object:**

```json
{  
   "customMetadata": {
      "what": "ever"
   },
   "err": {  
      "message": "Some exception",
      "name": "Error",
      "stack": "..."
   },
   "msg": "Some exception"
}
```