### PR TITLE
allow setting level with numbers as strings

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -285,6 +285,11 @@ var probes = dtrace && {};
 function resolveLevel(nameOrNum) {
     var level;
     var type = typeof (nameOrNum);
+    if (type === 'string' && /^-?\d+\.?\d*$/.test(nameOrNum)) {
+      //reconvert to number
+      nameOrNum = +nameOrNum;
+      type = typeof (nameOrNum);
+    }
     if (type === 'string') {
         level = levelFromName[nameOrNum.toLowerCase()];
         if (!level) {

--- a/test/level.test.js
+++ b/test/level.test.js
@@ -50,6 +50,12 @@ test('log.level(<num>)', function (t) {
     t.end();
 });
 
+test('log.level(<numAsString>)', function (t) {
+    log1.level('10');
+    t.equal(log1.level(), bunyan.TRACE);
+    t.end();
+})
+
 test('log.level(<name>)', function (t) {
     log1.level('error');
     t.equal(log1.level(), bunyan.ERROR);


### PR DESCRIPTION
I've started setting the desired logging level as an environment variable. If I want to take advantage of the trick to ignore all logs and set my env var to `'61'` (instead of `'FATAL'`) it will not work as the level resolver will try to lookup the string `'61'` (which does not exist).

This change adds a small check before the bulk of the resolver to check if a string has only digits (and a sign) and reconverts the `type` and the `nameOrNum`.

Changelog message: allows setting level with numbers as strings, e.g. '30'

I wasn't sure how you might prefer the additional check in the `resolveLevel` function. Adding extra logic to the if statements were quite cumbersome and these seemed the cleanest approach.