### PR TITLE
Remove old hack for Node 0.6

### DIFF
--- a/bin/bunyan
+++ b/bin/bunyan
@@ -1693,16 +1693,5 @@ function main(argv) {
 }
 
 if (require.main === module) {
-    // HACK guard for <https://github.com/trentm/json/issues/24>.
-    // We override the `process.stdout.end` guard that core node.js puts in
-    // place. The real fix is that `.end()` shouldn't be called on stdout
-    // in node core. Node v0.6.9 fixes that. Only guard for v0.6.0..v0.6.8.
-    if ([0, 6, 0] <= nodeVer && nodeVer <= [0, 6, 8]) {
-        var stdout = process.stdout;
-        stdout.end = stdout.destroy = stdout.destroySoon = function () {
-            /* pass */
-        };
-    }
-
     main(process.argv);
 }


### PR DESCRIPTION
Node 0.6 is no longer officially supported, and this questionable (comparing arrays containing numbers? .. how? :)) hack to get Node to play nice should probably no longer be a part of this codebase.

If anyone can explain why this array-comparison thing worked in the first place, I'm fascinated to hear it :) What are the JS mechanisms here?