### PR TITLE
express support: check req.originalUrl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,8 @@ Known issues:
 
 ## not yet released
 
-- Express support: inspect req.origialUrl, and, if present, prefer that over
-  req.url.
+(nothing yet)
+
 
 ## 2.0.2 (beta)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,8 @@ Known issues:
 
 ## not yet released
 
-(nothing yet)
-
+- Express support: inspect req.origialUrl, and, if present, prefer that over
+  req.url.
 
 ## 2.0.2 (beta)
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1090,7 +1090,7 @@ Logger.stdSerializers.req = function (req) {
         return req;
     return {
         method: req.method,
-        url: req.url,
+        url: req.originalUrl || req.url,
         headers: req.headers,
         remoteAddress: req.connection.remoteAddress,
         remotePort: req.connection.remotePort


### PR DESCRIPTION
This is a follow up to [a years-old abandoned PR from a different user](https://github.com/trentm/node-bunyan/pull/278).  Per that PR, I've added a new unit test to test this new feature, as well as made the change backward compatible for non-express usage.

CHANGES.md addition:
```
Express support: inspect req.originalUrl, and, if present, prefer that over req.url.
```

**Note**: I attempted to run `make check`, to confirm the code style, but ran into this error:

```
$ make check
./tools/jsstyle -o indent=4,doxygen,unparenthesized-return=0,blank-after-start-comment=0,leading-right-paren-ok=1 lib/bunyan.js test/add-stream.test.js test/buffer.test.js test/child-behaviour.test.js test/cli-client-req.test.js test/cli-res.test.js test/cli.test.js test/ctor.test.js test/cycles.test.js test/dtrace.test.js test/error-event.test.js test/level.test.js test/log-some-loop.js test/log-some.js test/log.test.js test/other-api.test.js test/process-exit.js test/process-exit.test.js test/raw-stream.test.js test/ringbuffer.test.js test/safe-json-stringify-1.js test/safe-json-stringify-2.js test/safe-json-stringify-3.js test/safe-json-stringify-4.js test/safe-json-stringify.test.js test/serializers.test.js test/src.test.js test/stream-levels.test.js test/tap4nodeunit.js tools/timechild.js tools/timeguard.js tools/timenop.js tools/timesrc.js examples/err.js examples/handle-fs-error.js examples/hi.js examples/level.js examples/log-undefined-values.js examples/long-running.js examples/multi.js examples/mute-by-envvars-stream.js examples/raw-stream.js examples/ringbuffer.js examples/rot-specific-levels.js examples/server.js examples/specific-level-streams.js examples/src.js examples/unstringifyable.js bin/bunyan
/bin/sh: json: command not found
version is:
[[ `cat package.json | json version` == `grep '^## ' CHANGES.md | head -2 | tail -1 | awk '{print $2}'` ]]
/bin/sh: json: command not found
make: *** [versioncheck] Error 1
```

I am on a Mac-- I couldn't find a `json` utility on home-brew.  Is this a custom program?  That being said, I ran this part of the command, and it executed without errors:
```
./tools/jsstyle -o indent=4,doxygen,unparenthesized-return=0,blank-after-start-comment=0,leading-right-paren-ok=1 lib/bunyan.js test/add-stream.test.js test/buffer.test.js test/child-behaviour.test.js test/cli-client-req.test.js test/cli-res.test.js test/cli.test.js test/ctor.test.js test/cycles.test.js test/dtrace.test.js test/error-event.test.js test/level.test.js test/log-some-loop.js test/log-some.js test/log.test.js test/other-api.test.js test/process-exit.js test/process-exit.test.js test/raw-stream.test.js test/ringbuffer.test.js test/safe-json-stringify-1.js test/safe-json-stringify-2.js test/safe-json-stringify-3.js test/safe-json-stringify-4.js test/safe-json-stringify.test.js test/serializers.test.js test/src.test.js test/stream-levels.test.js test/tap4nodeunit.js tools/timechild.js tools/timeguard.js tools/timenop.js tools/timesrc.js examples/err.js examples/handle-fs-error.js examples/hi.js examples/level.js examples/log-undefined-values.js examples/long-running.js examples/multi.js examples/mute-by-envvars-stream.js examples/raw-stream.js examples/ringbuffer.js examples/rot-specific-levels.js examples/server.js examples/specific-level-streams.js examples/src.js examples/unstringifyable.js bin/bunyan
```
