### PR TITLE
Don't clobber msg in record

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -979,7 +979,9 @@ function mkRecord(log, minLevel, args) {
             rec[k] = recFields[k];
         });
     }
-    rec.msg = format.apply(log, msgArgs);
+    if (!rec.msg) {
+        rec.msg = format.apply(log, msgArgs);
+    }
     if (!rec.time) {
         rec.time = (new Date());
     }

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -269,3 +269,13 @@ test('log.info(null, <msg>)', function (t) {
     });
     t.end();
 });
+
+test('log.info({msg})', function (t) {
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, {msg: 'my message'});
+        var rec = catcher.records[catcher.records.length - 1];
+        t.equal(rec.msg, 'my message',
+            format('log.%s msg: got %j', lvl, rec.msg));
+    });
+    t.end();
+});


### PR DESCRIPTION
This PR adds support for calling Bunyan with the message in the fields object. For example:

```
logger.info({msg: 'some message'});
```

In current Bunyan this results in:
```
{"name":"test-logger","hostname":"triton","pid":20662,"level":30,"msg":"","time":"2018-03-29T02:50:09.111Z","v":0}
```

After this PR you'll instead see:
```
{"name":"test-logger","hostname":"triton","pid":21403,"level":30,"msg":"some message","time":"2018-03-29T02:50:57.579Z","v":0}
```

Thanks :)