### PR TITLE
Use os.EOL for line endings for text loggers

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -906,7 +906,7 @@ Logger.prototype._emit = function (rec, noemit) {
     // Stringify the object (creates a warning str on error).
     var str;
     if (noemit || this.haveNonRawStreams) {
-        str = fastAndSafeJsonStringify(rec) + '\n';
+        str = fastAndSafeJsonStringify(rec) + os.EOL;
     }
 
     if (noemit)


### PR DESCRIPTION
This change uses `os.EOL` for line endings instead of `\n`

This is useful for those of us using NodeJS on Windows where the easiest log reader is Notepad.exe

Since the node runtime knows the platform, `os.EOL` is the most correct way to add a line ending to a text file

Fixes #589