### PR TITLE
Uncomment Logger.prototype.close

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -725,31 +725,28 @@ Logger.prototype.reopenFileStreams = function () {
     });
 };
 
-
-/* BEGIN JSSTYLED */
 /**
  * Close this logger.
  *
- * This closes streams (that it owns, as per 'endOnClose' attributes on
+ * This closes streams (that it owns, as per 'closeOnExit' attributes on
  * streams), etc. Typically you **don't** need to bother calling this.
+ */
 Logger.prototype.close = function () {
     if (this._closed) {
         return;
     }
+    var self = this;
     if (!this._isSimpleChild) {
         self.streams.forEach(function (s) {
-            if (s.endOnClose) {
+            if (s.closeOnExit) {
                 xxx('closing stream s:', s);
                 s.stream.end();
-                s.endOnClose = false;
+                s.closeOnExit = false;
             }
         });
     }
     this._closed = true;
 }
- */
-/* END JSSTYLED */
-
 
 /**
  * Get/set the level of all streams on this logger.


### PR DESCRIPTION
Closes #192 
Closes #365 
Closes #523 

Add close method back.

Since `createLogger()` may create lots streams that consumes file descriptor, so you may have to close the streams in the procedure by yourself.

And yes, as the followed comment said, `Typically you **don't** need to bother calling this`.
But it's always good to have the power control it.