### PR TITLE
🐞 fix bug preventing `rotating-file` stream from working

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -95,7 +95,7 @@ if (process.env.BUNYAN_TEST_NO_SAFE_JSON_STRINGIFY) {
 
 // The 'mv' module is required for rotating-file stream support.
 try {
-    var mv = require('mv' + '');
+    var mv = require('mv');
 } catch (e) {
     mv = null;
 }


### PR DESCRIPTION
The string addition here is messing up this require.  It bails when you try to use `rotating-file`.