### PR TITLE
Don't fatally fail if DTrace fails to initialize, but emit a warning

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -451,7 +451,13 @@ function Logger(options, _childOptions, _childSimple) {
             probe.dtp = dtp;
         }
 
-        dtp.enable();
+        try {
+            dtp.enable();
+        } catch(err) {
+            _warn(format('bunyan: WARN: Could not initialize DTrace provider.'
+                + 'This can happen if running inside a FreeBSD Jail.\n%s',
+                err.stack || err));
+        }
     }
 
     // Handle *config* options (i.e. options that are not just plain data


### PR DESCRIPTION
This PR adds a try/catch around dtp.enable() in `Logger`, and -- instead of failing fatally -- emits a warning in case enabling the DTrace provider fails.

A reason for this failing is that bunyan is used inside a FreeBSD jail, where DTrace cannot be loaded at runtime.