### PR TITLE
Update bunyan.js

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -980,8 +980,8 @@ function mkRecord(log, minLevel, args) {
         });
     }
     rec.msg = format.apply(log, msgArgs);
-    if (!rec.time) {
-        rec.time = (new Date());
+    if (!rec.timestamp) {
+        rec.timestamp = (new Date());
     }
     // Get call source info
     if (log.src && !rec.src) {


### PR DESCRIPTION
I found that field "time" has some issues with EFK when using `docker driver` and `filter parser`.

e.g.

```
<filter docker.**>
  @type parser
  format json
  key_name log
  reserve_data true
</filter>
```

Changing to `timestamp`, work fine.