### PR TITLE
Add tip about --no-optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ all versions of Bunyan logs. Therefore you might want to `npm install -g bunyan`
 to get the bunyan CLI on your PATH, then use local bunyan installs for
 node.js library usage of bunyan in your apps.
 
+**Tip**: Installing without optional dependencies can dramatically reduce
+bunyan's install size. **dtrace-provider** is used for dtrace features,
+**mv** is used for RotatingFileStream, and **moment** is used for local time.
+If you don't need these features, consider installing with the
+`--no-optional` flag.
+
 
 # Features
 


### PR DESCRIPTION
I noticed that installing bunyan 1.18.12 normally in an empty project gives me a node_modules size of 3.83 MB, while installing with `--no-optional` gives me 440 KB. I think this difference is significant enough to deserve mention in the README.