### PR TITLE
Fix Leaking of Environment Variables

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1022,10 +1022,11 @@ function mkLogEmitter(minLevel) {
              */
             var dedupKey = 'unbound';
             if (!_haveWarned[dedupKey]) {
+                var stack = new Error().stack
                 var caller = getCaller3Info();
                 _warn(format('bunyan usage error: %s:%s: attempt to log '
-                    + 'with an unbound log method: `this` is: %s',
-                    caller.file, caller.line, util.inspect(this)),
+                    + 'with an unbound log method: %s',
+                    caller.file, caller.line, stack),
                     dedupKey);
             }
             return;


### PR DESCRIPTION
## Description
Bunyan leaks out environment variables if **this** is not defined when log.info is called. This changes the default behavior to output the current stack trace as suggested here: https://github.com/trentm/node-bunyan/issues/565

I've created a repository which reproduces this issue here: https://github.com/kamranjon/bunyan-leak

## References
[ISSUE-565](https://github.com/trentm/node-bunyan/issues/565)

## Notes
Open to other solutions but this seemed like the safest option that also returns useful output. 