### PR TITLE
Child create name restriction

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -684,7 +684,7 @@ Logger.prototype.addSerializers = function addSerializers(serializers) {
  *    creation. See 'tools/timechild.js' for numbers.
  */
 Logger.prototype.child = function (options, simple) {
-    return new (this.constructor)(this, options || {}, simple);
+    return new (this.constructor)(this, {...options, name: undefined} || {}, simple);
 }
 
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -684,7 +684,9 @@ Logger.prototype.addSerializers = function addSerializers(serializers) {
  *    creation. See 'tools/timechild.js' for numbers.
  */
 Logger.prototype.child = function (options, simple) {
-    return new (this.constructor)(this, {...options, name: undefined} || {}, simple);
+    return new (this.constructor)(this, Object.assign(options, {
+        name: undefined
+    }) || {}, simple);
 }
 
 

--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -684,9 +684,11 @@ Logger.prototype.addSerializers = function addSerializers(serializers) {
  *    creation. See 'tools/timechild.js' for numbers.
  */
 Logger.prototype.child = function (options, simple) {
-    return new (this.constructor)(this, Object.assign(options, {
-        name: undefined
-    }) || {}, simple);
+    if (options) {
+        options.name = undefined;
+    }
+    
+    return new (this.constructor)(this, options || {}, simple);
 }
 
 


### PR DESCRIPTION
## Problem

Can't create child logger, because `.child` method just forward options from parent with `name` property. But Logger constructor restrict this property for child logger.

## Solution

Not forward name property for child logger