### PR TITLE
fix 'make check' in GH actions env; fix 'test' action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     - 'docs/**'
     - '*.md'
   pull_request:
+    paths-ignore:
     - 'docs/**'
     - '*.md'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,13 @@ on:
 jobs:
   # Test once on every (available) plat, using LTS node version
   # (https://nodejs.org/en/about/releases/).
+  #
+  # TODO: add windows-latest when moved to node-tap and don't have to
+  # rely on shell globbing
   test-plats:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.log
 !/test/corpus/*.log
 /*.tgz
-/test/*.log.0
+/test/log.test.rot.log.*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+SHELL := bash
+
 #---- Tools
 
 NODEUNIT := ./node_modules/.bin/nodeunit

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ all $(NODEUNIT):
 # Ensure all version-carrying files have the same version.
 .PHONY: versioncheck
 versioncheck:
-	@echo version is: $(shell cat package.json | json version)
-	[[ `cat package.json | json version` == `grep '^## ' CHANGES.md | head -2 | tail -1 | awk '{print $$2}'` ]]
+	@echo version is: $(shell node -e 'console.log(require("./package.json").version)')
+	[[ `node -e 'console.log(require("./package.json").version)'` == `grep '^## ' CHANGES.md | head -2 | tail -1 | awk '{print $$2}'` ]]
 	@echo Version check ok.
 
 .PHONY: cutarelease

--- a/tools/jsstyle
+++ b/tools/jsstyle
@@ -767,8 +767,8 @@ process_indent($)
 
 	# skip over enumerations, array definitions, initializers, etc.
 	if ($cont_off <= 0 && !/^\s*$special/ &&
-	    (/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*)){/ ||
-	    (/^\s*{/ && $prev =~ /=\s*(?:\/\*.*\*\/\s*)*$/))) {
+	    (/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*))\{/ ||
+	    (/^\s*\{/ && $prev =~ /=\s*(?:\/\*.*\*\/\s*)*$/))) {
 		$cont_in = 0;
 		$cont_off = tr/{/{/ - tr/}/}/;
 		return;

--- a/tools/jsstyle
+++ b/tools/jsstyle
@@ -649,7 +649,7 @@ line: while (<$filehandle>) {
 	if (/^\s*\(void\)[^ ]/) {
 		err("missing space after (void) cast");
 	}
-	if (/\S{/ && !/({|\(){/ &&
+	if (/\S\{/ && !/(\{|\()\{/ &&
 	    # Allow a brace in a regex quantifier.
 	    !/\/.*?\{\d+,?\d*\}.*?\//) {
 		err("missing space before left brace");


### PR DESCRIPTION
The newer Perl (5.26.1) dislikes unescaped '{' in tools/jsstyle regexes.
Also drop the implicit dep on `json` for 'make versioncheck'.