### PR TITLE
Fix Python 3 incompatibilities in cutarelease.py

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,3 +10,5 @@ jobs:
         node-version: '12.x'
     - run: npm ci
     - run: npm run check
+    - run: python3 -m pip install flake8
+    - run: python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/tools/cutarelease.py
+++ b/tools/cutarelease.py
@@ -28,15 +28,18 @@ import optparse
 import json
 import time
 
-
+try:
+    raw_input  # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 #---- globals and config
 
 log = logging.getLogger("cutarelease")
 
+
 class Error(Exception):
     pass
-
 
 
 #---- main functionality
@@ -112,7 +115,7 @@ def cutarelease(project_name, version_files, dry_run=False):
             "Are you sure you want cut a %s release?\n"
             "This will involved commits and a push." % version,
             default="no")
-        print "* * *"
+        print("* * *")
         if answer != "yes":
             log.info("user abort")
             return
@@ -136,7 +139,7 @@ def cutarelease(project_name, version_files, dry_run=False):
             "The changelog '%s' top section doesn't have the expected\n"
             "'%s' marker. Has this been released already?"
             % (changes_path, nyr), default="yes")
-        print "* * *"
+        print("* * *")
         if answer != "no":
             log.info("abort")
             return
@@ -167,7 +170,7 @@ def cutarelease(project_name, version_files, dry_run=False):
     # Optionally release.
     if exists("package.json"):
         answer = query_yes_no("\n* * *\nPublish to npm?", default="yes")
-        print "* * *"
+        print("* * *")
         if answer == "yes":
             if dry_run:
                 log.info("skipping npm publish (dry-run)")
@@ -175,7 +178,7 @@ def cutarelease(project_name, version_files, dry_run=False):
                 run('npm publish')
     elif exists("setup.py"):
         answer = query_yes_no("\n* * *\nPublish to pypi?", default="yes")
-        print "* * *"
+        print("* * *")
         if answer == "yes":
             if dry_run:
                 log.info("skipping pypi publish (dry-run)")


### PR DESCRIPTION
`raw_input()` was removed in Python 3 in favor of `input()`.

Use `print()` function in both Python 2 and Python 3.

Lint Python code to avoid future regressions...

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.