### PR TITLE
Fixes for Webpack 5 browser environments

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -518,7 +518,7 @@ function Logger(options, _childOptions, _childSimple) {
     if (!fields.hostname && !self.fields.hostname) {
         fields.hostname = os.hostname();
     }
-    if (!fields.pid) {
+    if (!fields.pid && runtimeEnv !== 'browser') {
         fields.pid = process.pid;
     }
     Object.keys(fields).forEach(function (k) {
@@ -950,7 +950,7 @@ function mkRecord(log, minLevel, args) {
         // `log.<level>(msg, ...)`
         fields = null;
         msgArgs = args.slice();
-    } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
+    } else if (typeof (Buffer) !== 'undefined' && Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
         // Almost certainly an error, show `inspect(buf)`. See bunyan
         // issue #35.
         fields = null;


### PR DESCRIPTION
Webpack 5 no longer automatically provides polyfills for Node APIs from browser environments.  (See "Automatic polyfills for native Node.js modules were removed" under the [Webpack 5 release announcement][1].) This causes problems for Bunyan's use of Node.js-only globals like `process` and `Buffer`.

As I understand it, one solution is to do an explicit `require` and, if needed, [configure Webpack's resolve.fallback option][2] to specify how to resolve the `require`d modules. (Bunyan does something similar to this for the `os` and `fs` modules.)

The other solution is to check whether the modules are available before continuing.

I opted for the second solution in this PR, to avoid introducing a dependency on the [buffer][3] module.  This means that Bunyan won't directly support Buffer objects in the browser.

There are two references to `process` that I didn't update: `process.env` check and a reference to `process.stderr.write`. `process.env` is specially handled by Node.js, and `process.stderr` is addressed by #628.

[1]: https://webpack.js.org/blog/2020-10-10-webpack-5-release/
[2]: https://stackoverflow.com/q/64557638/25507
[3]: https://www.npmjs.com/package/buffer