### PR TITLE
Extend VError support to include Error Cause proposal support

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1127,8 +1127,8 @@ Logger.stdSerializers.res = function (res) {
 function getFullErrorStack(ex)
 {
     var ret = ex.stack || ex.toString();
-    if (ex.cause && typeof (ex.cause) === 'function') {
-        var cex = ex.cause();
+    if (ex.cause) {
+        var cex = typeof (ex.cause) === 'function' ? ex.cause() : ex.cause;
         if (cex) {
             ret += '\nCaused by: ' + getFullErrorStack(cex);
         }


### PR DESCRIPTION
See https://github.com/tc39/proposal-error-cause and https://github.com/tc39/proposal-error-cause/issues/31 – a stage 3 proposal for including a VError style property to the JS language itself.