### PR TITLE
Used getter function of response header

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1110,7 +1110,7 @@ Logger.stdSerializers.res = function (res) {
         return res;
     return {
         statusCode: res.statusCode,
-        header: res._header
+        header: res.getHeaders()
     }
 };
 


### PR DESCRIPTION
To set headers properly on the standard serializer for response details instead of letting `header` property to `null`

![image](https://user-images.githubusercontent.com/19700174/127088197-9cbda8a0-bab6-4034-bbbe-a774fe79438c.png)
