### PR TITLE
Correct `webpack` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,7 +1389,8 @@ Mark the following dependencies as
 configuration file to exclude them from the bundle:
 
 ```
-module: {
+module.exports = {
+    //...
     externals: ['dtrace-provider', 'fs', 'mv', 'os', 'source-map-support']
 }
 ```


### PR DESCRIPTION
Fixes `webpack` example which hinted that external items are provided at
`{ module: { externals: /* ... */ } }`, instead of at the top-level.