### PR TITLE
add documentation on how to end a stream.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/node-bunyan.iml" filepath="$PROJECT_DIR$/.idea/node-bunyan.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/node-bunyan.iml
+++ b/.idea/node-bunyan.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -793,6 +793,27 @@ log.addStream({
 });
 ```
 
+## Ending a Stream
+
+After a bunyan instance has been initialized, and a stream has been added you may end the stream like so:
+
+```js
+const log = bunyan.createLogger({
+  name: 'myLogger',
+  streams: [
+    {
+      level: 'info',
+      format: 'json',
+      path: `myNewStream.log`,
+    }
+  ],
+});
+
+log.streams[0].stream.end();
+```
+
+
+
 ## stream errors
 
 A Bunyan logger instance can be made to re-emit "error" events from its


### PR DESCRIPTION
I'm not sure what JSSTYLED was supposed to be doing, but the close stream function has been commented out since [#1a916f6ad7b1e731d1ea04ad4e44cc1db2cf4e94](https://github.com/trentm/node-bunyan/commit/1a916f6ad7b1e731d1ea04ad4e44cc1db2cf4e94). In the absence of that getting changed, I think this documentation can help people with ending a stream. I found this useful in a node application to push its own logs over to s3.