### PR TITLE
fix: bump moment to 2.29.4 in optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   "// moment": "required for local time with CLI",
   "optionalDependencies": {
     "dtrace-provider": "~0.8",
+    "moment": "^2.29.4",
     "mv": "~2",
-    "safe-json-stringify": "~1",
-    "moment": "^2.19.3"
+    "safe-json-stringify": "~1"
   },
   "devDependencies": {
     "ben": "0.0.0",


### PR DESCRIPTION
Fixes #692 

The order of the dependencies is changed because `npm install --save-optional x` puts dependencies in alphabetical order.