### PR TITLE
set os.EOL for browser environments

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -66,7 +66,8 @@ if (runtimeEnv === 'browser') {
     os = {
         hostname: function () {
             return window.location.host;
-        }
+        },
+        EOL: '\n'
     };
     fs = {};
     dtrace = null;


### PR DESCRIPTION
Add a value (new line) for `os.EOL` for browser envs to use here:
https://github.com/trentm/node-bunyan/blob/5c2258ecb1d33ba34bd7fbd6167e33023dc06e40/lib/bunyan.js#L909