### PR TITLE
test: reduce flakiness by taking control of environment

### DIFF
--- a/test/process-exit.test.js
+++ b/test/process-exit.test.js
@@ -16,7 +16,8 @@ if (nodeVer[0] <= 0 && nodeVer[1] <= 8) {
     console.warn('skip test (node <= 0.8)');
 } else {
     test('log with rotating file stream will terminate', function (t) {
-        exec('node ' +__dirname + '/process-exit.js', {timeout: 1000},
+        exec('node ' +__dirname + '/process-exit.js',
+                {timeout: 1000, env: { PATH: process.env.PATH }},
                 function (err, stdout, stderr) {
             t.ifError(err);
             t.equal(stdout, 'done\n');


### PR DESCRIPTION
I use vs code with auto-attach, which creates data in STDERR This controls the ENV passed through to child-process Technically I think it improves the test:

## Before

```
test/process-exit.test.js ............................. 2/3
  log with rotating file stream will terminate
  not ok should be equal
    --- wanted                                                                       
    +++ found                                                                        
    +Debugger listening on ws://127.0.0.1:64184/64dcdc5d-8cbd-407a-aed4-32c4b033d814 
    +For help, see: https://nodejs.org/en/docs/inspector                             
    +Debugger attached.                                                              
    +Waiting for the debugger to disconnect...                                       
    compare: '==='
    at:
      line: 23
      column: 15
      file: test/process-exit.test.js
    stack: |
      test/process-exit.test.js:23:15
      ChildProcess.exithandler (node:child_process:390:7)
      ChildProcess.emit (node:events:527:28)
      maybeClose (node:internal/child_process:1092:16)
      Process.ChildProcess._handle.onexit (node:internal/child_process:302:5)
    source: |
      t.equal(stderr, '');

```

## After

```
test/process-exit.test.js ...Waiting for the debugger to disconnect...
Debugger listening on ws://127.0.0.1:64396/e1e9cf0b-2827-4ccb-b2be-b7c848953d3d
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
test/process-exit.test.js ............................. 3/3
```

So technically what is happening is that the child process was receiving some ENV which told it to debug. I initially tried setting `LOG_LEVEL=fatal`, without passing anything from `process.env`; this was a mistake, as `process.env.PATH` is needed (at least on my machine) to use `nodejs`. So with that sent in, and a bit of pokery to get `npm run check` passing, this should meet standards.