### PR TITLE
Instantiating the Error class to call prepareStackTrace

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -183,10 +183,10 @@ function getCaller3Info() {
     var obj = {};
     var saveLimit = Error.stackTraceLimit;
     var savePrepare = Error.prepareStackTrace;
-    Error.stackTraceLimit = 3;
+    Error.stackTraceLimit = 4;
 
     Error.prepareStackTrace = function (_, stack) {
-        var caller = stack[2];
+        var caller = stack[3];
         if (sourceMapSupport) {
             caller = sourceMapSupport.wrapCallSite(caller);
         }
@@ -197,7 +197,8 @@ function getCaller3Info() {
             obj.func = func;
     };
     Error.captureStackTrace(this, getCaller3Info);
-    this.stack;
+    const err = new Error();
+    err.stack;
 
     Error.stackTraceLimit = saveLimit;
     Error.prepareStackTrace = savePrepare;


### PR DESCRIPTION
Using src:true isn't work in new Node versions.  


```javascript
const log = bunyan.createLogger({
  name: "test",
  src: true,
});
```

Fixes: https://github.com/trentm/node-bunyan/issues/714

As of Node 20.1.0 if you don't call `new Error()` the method `prepareStackTrace` isn't called.  

Nodejs issue: https://github.com/nodejs/node/issues/49681


Before the correction, using a Node version starting from 20.1.0, log.info returns an empty src.   
```js
//index.js
const bunyan = require("bunyan");
const log = bunyan.createLogger({name: "test", src: true});
log.info("test");
```
```sh
$ nvm use 18
$ node index.js

$ nvm use 20.5.0
$ node index.js
```
----

## TESTS  

There is a test for src named: `src.test.js` and using node version 20.1.0 or latter it breaks at line 45.  